### PR TITLE
AD-53 Scaffolds Ballot Hashing

### DIFF
--- a/TrueVote.Api.Tests/HelperTests/MerkleTreeTest.cs
+++ b/TrueVote.Api.Tests/HelperTests/MerkleTreeTest.cs
@@ -1,3 +1,4 @@
+using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -47,10 +48,12 @@ namespace TrueVote.Api.Tests.HelperTests
         [Fact]
         public void CreatesMerkleRootFromBallotObject()
         {
-            var merkleRoot = MerkleTree.CalculateMerkleRoot(MoqData.MockBallotData);
+            var dataJson = JsonConvert.SerializeObject(MoqData.MockBallotData);
+
+            var merkleRoot = MerkleTree.CalculateMerkleRoot(dataJson);
 
             Assert.NotNull(merkleRoot);
-            Assert.Equal("147", merkleRoot[0].ToString());
+            Assert.Equal("91", merkleRoot[0].ToString());
         }
 
         [Fact]
@@ -58,15 +61,20 @@ namespace TrueVote.Api.Tests.HelperTests
         {
             var data1 = MoqData.MockBallotData;
             var data2 = MoqData.MockBallotData;
-            Assert.Equal(data1, data2);
 
-            var hash1 = MerkleTree.GetHash(data1);
-            var hash2 = MerkleTree.GetHash(data1);
+            var data1Json = JsonConvert.SerializeObject(data1);
+            var data2Json = JsonConvert.SerializeObject(data2);
+
+            Assert.Equal(data1Json, data2Json);
+
+            var hash1 = MerkleTree.GetHash(data1Json);
+            var hash2 = MerkleTree.GetHash(data2Json);
 
             Assert.NotNull(hash1);
             Assert.NotNull(hash2);
             Assert.Equal(hash1, hash2);
-            Assert.Equal("126", hash1[0].ToString());
+            Assert.Equal("157", hash1[0].ToString());
+            Assert.Equal("157", hash2[0].ToString());
         }
     }
 }

--- a/TrueVote.Api.Tests/HelperTests/MerkleTreeTest.cs
+++ b/TrueVote.Api.Tests/HelperTests/MerkleTreeTest.cs
@@ -1,0 +1,72 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using TrueVote.Api.Helpers;
+using Xunit;
+
+namespace TrueVote.Api.Tests.HelperTests
+{
+    public class MerkleTreeTest
+    {
+        [Fact]
+        public void CreatesMerkleRootFromSimpleString()
+        {
+            var testList = new List<string>
+            {
+                "A test string"
+            };
+
+            var merkleRoot = MerkleTree.CalculateMerkleRoot(testList);
+
+            Assert.NotNull(merkleRoot);
+            Assert.Equal("56", merkleRoot[0].ToString());
+        }
+
+        [Fact]
+        public void CreatesMerkleRootFromMultipleStrings()
+        {
+            var testList = new List<string>
+            {
+                "A test string - 1",
+                "A test string - 2",
+                "A test string - 3",
+                "A test string - 4",
+                "A test string - 5",
+                "A test string - 6",
+                "A test string - 7",
+            };
+
+            var merkleRoot = MerkleTree.CalculateMerkleRoot(testList);
+
+            Assert.NotNull(merkleRoot);
+            Assert.Equal("140", merkleRoot[0].ToString());
+        }
+
+        [Fact]
+        public void CreatesMerkleRootFromBallotObject()
+        {
+            var merkleRoot = MerkleTree.CalculateMerkleRoot(MoqData.MockBallotData);
+
+            Assert.NotNull(merkleRoot);
+            Assert.Equal("147", merkleRoot[0].ToString());
+        }
+
+        [Fact]
+        public void CreatesHashFromBallotObject()
+        {
+            var data1 = MoqData.MockBallotData;
+            var data2 = MoqData.MockBallotData;
+            Assert.Equal(data1, data2);
+
+            var hash1 = MerkleTree.GetHash(data1);
+            var hash2 = MerkleTree.GetHash(data1);
+
+            Assert.NotNull(hash1);
+            Assert.NotNull(hash2);
+            Assert.Equal(hash1, hash2);
+            Assert.Equal("126", hash1[0].ToString());
+        }
+    }
+}

--- a/TrueVote.Api.Tests/HelperTests/MerkleTreeTest.cs
+++ b/TrueVote.Api.Tests/HelperTests/MerkleTreeTest.cs
@@ -1,10 +1,7 @@
 using Newtonsoft.Json;
-using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using TrueVote.Api.Helpers;
+using TrueVote.Api.Models;
 using Xunit;
 
 namespace TrueVote.Api.Tests.HelperTests
@@ -75,6 +72,36 @@ namespace TrueVote.Api.Tests.HelperTests
             Assert.Equal(hash1, hash2);
             Assert.Equal("157", hash1[0].ToString());
             Assert.Equal("157", hash2[0].ToString());
+        }
+
+        [Fact]
+        public void HandlesNullString()
+        {
+            string dataString = null;
+
+            var merkleRoot = MerkleTree.CalculateMerkleRoot(dataString);
+
+            Assert.Null(merkleRoot);
+        }
+
+        [Fact]
+        public void HandlesNullObject()
+        {
+            List<BallotModel> dataObject = null;
+
+            var merkleRoot = MerkleTree.CalculateMerkleRoot(dataObject);
+
+            Assert.Null(merkleRoot);
+        }
+
+        [Fact]
+        public void HandlesEmptyObject()
+        {
+            var dataObject = new List<BallotModel>();
+
+            var merkleRoot = MerkleTree.CalculateMerkleRoot(dataObject);
+
+            Assert.Null(merkleRoot);
         }
     }
 }

--- a/TrueVote.Api.Tests/Helpers/OpenTimestampsTest.cs
+++ b/TrueVote.Api.Tests/Helpers/OpenTimestampsTest.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+using Moq;
+using Moq.Protected;
+using Xunit;
+
+namespace TrueVote.Api.Helpers.Tests
+{
+    public class OpenTimestampsTests
+    {
+        private static OpenTimestampsClient CreateOpenTimestampsClient(HttpClient httpClient)
+        {
+            var uri = new Uri("https://example.com");
+            return new OpenTimestampsClient(uri, httpClient);
+        }
+
+        private static HttpClient CreateHttpClient(HttpResponseMessage response)
+        {
+            var mockHttpMessageHandler = new Mock<HttpMessageHandler>();
+            mockHttpMessageHandler
+                .Protected()
+                .Setup<Task<HttpResponseMessage>>(
+                    "SendAsync",
+                    ItExpr.IsAny<HttpRequestMessage>(),
+                    ItExpr.IsAny<CancellationToken>()
+                )
+                .ReturnsAsync(response);
+
+            var httpClient = new HttpClient(mockHttpMessageHandler.Object);
+            return httpClient;
+        }
+
+        [Fact]
+        public async Task StampReturnsTimestampBytes()
+        {
+            var expectedBytes = new byte[] { 0x01, 0x02, 0x03 };
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new ByteArrayContent(expectedBytes)
+            };
+            var httpClient = CreateHttpClient(response);
+            var openTimestampsClient = CreateOpenTimestampsClient(httpClient);
+
+            var result = await openTimestampsClient.Stamp(new byte[32]);
+
+            Assert.Equal(expectedBytes, result);
+        }
+
+        [Fact]
+        public async Task StampRequestFailsThrowsException()
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.InternalServerError);
+            var httpClient = CreateHttpClient(response);
+            var openTimestampsClient = CreateOpenTimestampsClient(httpClient);
+
+            try
+            {
+                var result = await openTimestampsClient.Stamp(new byte[32]);
+                Assert.True(false);
+            }
+            catch (Exception ex)
+            {
+                Assert.NotNull(ex);
+                Assert.Contains("500 (Internal Server Error).", ex.Message);
+            }
+        }
+    }
+}

--- a/TrueVote.Api.Tests/Helpers/TestHelper.cs
+++ b/TrueVote.Api.Tests/Helpers/TestHelper.cs
@@ -26,6 +26,7 @@ namespace TrueVote.Api.Tests.Helpers
         protected readonly Ballot _ballotApi;
         protected readonly Race _raceApi;
         protected readonly Candidate _candidateApi;
+        protected readonly Validator _validatorApi;
         protected readonly GraphQLExecutor _graphQLApi;
         protected readonly MoqDataAccessor _moqDataAccessor;
         protected readonly Mock<TelegramBot> _mockTelegram;
@@ -73,6 +74,7 @@ namespace TrueVote.Api.Tests.Helpers
             _raceApi = new Race(_logHelper.Object, _moqDataAccessor.mockRaceContext.Object, _mockTelegram.Object);
             _candidateApi = new Candidate(_logHelper.Object, _moqDataAccessor.mockCandidateContext.Object, _mockTelegram.Object);
             _graphQLApi = new GraphQLExecutor(_logHelper.Object, _mockTelegram.Object);
+            _validatorApi = new Validator(_logHelper.Object, _moqDataAccessor.mockBallotContext.Object, _mockTelegram.Object);
         }
     }
 }

--- a/TrueVote.Api.Tests/Helpers/TestHelper.cs
+++ b/TrueVote.Api.Tests/Helpers/TestHelper.cs
@@ -6,7 +6,6 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
 using Microsoft.Extensions.Logging;
 using Moq;
-using System;
 using System.IO;
 using System.IO.Abstractions;
 using System.Threading.Tasks;
@@ -83,7 +82,7 @@ namespace TrueVote.Api.Tests.Helpers
             _candidateApi = new Candidate(_logHelper.Object, _moqDataAccessor.mockCandidateContext.Object, _mockTelegram.Object);
             _graphQLApi = new GraphQLExecutor(_logHelper.Object, _mockTelegram.Object);
             _validatorApi = new Validator(_logHelper.Object, _moqDataAccessor.mockBallotContext.Object, _mockTelegram.Object, _mockOpenTimestampsClient.Object);
-            _timestampApi = new Timestamp(_logHelper.Object, _moqDataAccessor.mockUserContext.Object, _mockTelegram.Object);
+            _timestampApi = new Timestamp(_logHelper.Object, _moqDataAccessor.mockTimestampContext.Object, _mockTelegram.Object);
         }
     }
 }

--- a/TrueVote.Api.Tests/Helpers/TestHelper.cs
+++ b/TrueVote.Api.Tests/Helpers/TestHelper.cs
@@ -29,6 +29,7 @@ namespace TrueVote.Api.Tests.Helpers
         protected readonly Race _raceApi;
         protected readonly Candidate _candidateApi;
         protected readonly Validator _validatorApi;
+        protected readonly Timestamp _timestampApi;
         protected readonly GraphQLExecutor _graphQLApi;
         protected readonly MoqDataAccessor _moqDataAccessor;
         protected readonly Mock<TelegramBot> _mockTelegram;
@@ -82,6 +83,7 @@ namespace TrueVote.Api.Tests.Helpers
             _candidateApi = new Candidate(_logHelper.Object, _moqDataAccessor.mockCandidateContext.Object, _mockTelegram.Object);
             _graphQLApi = new GraphQLExecutor(_logHelper.Object, _mockTelegram.Object);
             _validatorApi = new Validator(_logHelper.Object, _moqDataAccessor.mockBallotContext.Object, _mockTelegram.Object, _mockOpenTimestampsClient.Object);
+            _timestampApi = new Timestamp(_logHelper.Object, _moqDataAccessor.mockUserContext.Object, _mockTelegram.Object);
         }
     }
 }

--- a/TrueVote.Api.Tests/MoqData.cs
+++ b/TrueVote.Api.Tests/MoqData.cs
@@ -50,6 +50,13 @@ namespace TrueVote.Api.Tests
             new RaceModel { RaceId = "raceid2", Name = "Judge", DateCreated = createDate2, RaceType = RaceTypes.ChooseMany },
             new RaceModel { RaceId = "raceid3", Name = "Governor", DateCreated = createDate3, RaceType = RaceTypes.ChooseOne }
         };
+
+        public static List<TimestampModel> MockTimestampData => new()
+        {
+            new TimestampModel { },
+            new TimestampModel { }
+        };
+
     }
 
     public class MoqDataAccessor
@@ -59,6 +66,7 @@ namespace TrueVote.Api.Tests
         public readonly Mock<MoqTrueVoteDbContext> mockBallotContext;
         public readonly Mock<MoqTrueVoteDbContext> mockCandidateContext;
         public readonly Mock<MoqTrueVoteDbContext> mockRaceContext;
+        public readonly Mock<MoqTrueVoteDbContext> mockTimestampContext;
         public readonly IQueryable<UserModel> mockUserDataQueryable;
         public readonly IQueryable<ElectionModel> mockElectionDataQueryable;
         public readonly IQueryable<BallotModel> mockBallotDataQueryable;
@@ -66,12 +74,15 @@ namespace TrueVote.Api.Tests
         public readonly ICollection<CandidateModel> mockCandidateDataCollection;
         public readonly IQueryable<RaceModel> mockRaceDataQueryable;
         public readonly ICollection<RaceModel> mockRaceDataCollection;
+        public readonly IQueryable<TimestampModel> mockTimestampDataQueryable;
+        public readonly ICollection<TimestampModel> mockTimestampDataCollection;
 
         public Mock<DbSet<UserModel>> mockUserSet { get; private set; }
         public Mock<DbSet<RaceModel>> mockRaceSet { get; private set; }
         public Mock<DbSet<CandidateModel>> mockCandidateSet { get; private set; }
         public Mock<DbSet<ElectionModel>> mockElectionSet { get; private set; }
         public Mock<DbSet<BallotModel>> mockBallotSet { get; private set; }
+        public Mock<DbSet<TimestampModel>> mockTimestampSet { get; private set; }
 
         // https://docs.microsoft.com/en-us/ef/ef6/fundamentals/testing/mocking?redirectedfrom=MSDN
         // https://github.com/romantitov/MockQueryable
@@ -102,6 +113,14 @@ namespace TrueVote.Api.Tests
             mockCandidateContext.Setup(m => m.Candidates).Returns(mockCandidateSet.Object);
             mockCandidateContext.Setup(m => m.EnsureCreatedAsync()).Returns(Task.FromResult(true));
 
+            mockTimestampContext = new Mock<MoqTrueVoteDbContext>();
+            mockTimestampDataQueryable = MoqData.MockTimestampData.AsQueryable();
+            mockTimestampDataCollection = MoqData.MockTimestampData;
+            mockTimestampSet = DbMoqHelper.GetDbSet(mockTimestampDataQueryable);
+            mockTimestampContext.Setup(m => m.Timestamps).Returns(mockTimestampSet.Object);
+            mockTimestampContext.Setup(m => m.EnsureCreatedAsync()).Returns(Task.FromResult(true));
+            mockBallotContext.Setup(m => m.Timestamps).Returns(mockTimestampSet.Object);
+
             mockRaceContext = new Mock<MoqTrueVoteDbContext>();
             MoqData.MockRaceData[0].RaceId = "1";
             // TODO Fix this assignment
@@ -124,6 +143,7 @@ namespace TrueVote.Api.Tests
         public virtual DbSet<RaceModel> Races { get; set; }
         public virtual DbSet<CandidateModel> Candidates { get; set; }
         public virtual DbSet<BallotModel> Ballots { get; set; }
+        public virtual DbSet<TimestampModel> Timestamps { get; set; }
 
         protected MoqDataAccessor _moqDataAccessor;
 
@@ -136,6 +156,7 @@ namespace TrueVote.Api.Tests
             Races = _moqDataAccessor.mockRaceSet.Object;
             Candidates = _moqDataAccessor.mockCandidateSet.Object;
             Ballots = _moqDataAccessor.mockBallotSet.Object;
+            Timestamps = _moqDataAccessor.mockTimestampSet.Object;
         }
 
         public virtual async Task<bool> EnsureCreatedAsync()

--- a/TrueVote.Api.Tests/MoqData.cs
+++ b/TrueVote.Api.Tests/MoqData.cs
@@ -11,11 +11,11 @@ namespace TrueVote.Api.Tests
 {
     public static class MoqData
     {
-        public static DateTime startDate = DateTime.Parse("2023-02-25");
-        public static DateTime endDate = DateTime.Parse("2023-02-25").AddDays(30);
-        public static DateTime createDate = DateTime.Parse("2022-12-17");
-        public static DateTime createDate2 = DateTime.Parse("2022-12-17").AddHours(1);
-        public static DateTime createDate3 = DateTime.Parse("2022-12-17").AddHours(2);
+        private static readonly DateTime startDate = DateTime.Parse("2023-02-25");
+        private static readonly DateTime endDate = DateTime.Parse("2023-02-25").AddDays(30);
+        private static readonly DateTime createDate = DateTime.Parse("2022-12-17");
+        private static readonly DateTime createDate2 = DateTime.Parse("2022-12-17").AddHours(1);
+        private static readonly DateTime createDate3 = DateTime.Parse("2022-12-17").AddHours(2);
 
         public static List<UserModel> MockUserData => new()
         {

--- a/TrueVote.Api.Tests/MoqData.cs
+++ b/TrueVote.Api.Tests/MoqData.cs
@@ -53,8 +53,8 @@ namespace TrueVote.Api.Tests
 
         public static List<TimestampModel> MockTimestampData => new()
         {
-            new TimestampModel { },
-            new TimestampModel { }
+            new TimestampModel { TimestampId = "1", TimestampHashS = "SampleHash1", DateCreated = new DateTime(2023, 01, 01, 11, 11, 11) },
+            new TimestampModel { TimestampId = "2", TimestampHashS = "SampleHash2", DateCreated = new DateTime(2023, 01, 01, 11, 11, 21) }
         };
 
     }
@@ -77,12 +77,12 @@ namespace TrueVote.Api.Tests
         public readonly IQueryable<TimestampModel> mockTimestampDataQueryable;
         public readonly ICollection<TimestampModel> mockTimestampDataCollection;
 
-        public Mock<DbSet<UserModel>> mockUserSet { get; private set; }
-        public Mock<DbSet<RaceModel>> mockRaceSet { get; private set; }
-        public Mock<DbSet<CandidateModel>> mockCandidateSet { get; private set; }
-        public Mock<DbSet<ElectionModel>> mockElectionSet { get; private set; }
-        public Mock<DbSet<BallotModel>> mockBallotSet { get; private set; }
-        public Mock<DbSet<TimestampModel>> mockTimestampSet { get; private set; }
+        public Mock<DbSet<UserModel>> MockUserSet { get; private set; }
+        public Mock<DbSet<RaceModel>> MockRaceSet { get; private set; }
+        public Mock<DbSet<CandidateModel>> MockCandidateSet { get; private set; }
+        public Mock<DbSet<ElectionModel>> MockElectionSet { get; private set; }
+        public Mock<DbSet<BallotModel>> MockBallotSet { get; private set; }
+        public Mock<DbSet<TimestampModel>> MockTimestampSet { get; private set; }
 
         // https://docs.microsoft.com/en-us/ef/ef6/fundamentals/testing/mocking?redirectedfrom=MSDN
         // https://github.com/romantitov/MockQueryable
@@ -90,36 +90,36 @@ namespace TrueVote.Api.Tests
         {
             mockUserContext = new Mock<MoqTrueVoteDbContext>();
             mockUserDataQueryable = MoqData.MockUserData.AsQueryable();
-            mockUserSet = DbMoqHelper.GetDbSet(mockUserDataQueryable);
-            mockUserContext.Setup(m => m.Users).Returns(mockUserSet.Object);
+            MockUserSet = DbMoqHelper.GetDbSet(mockUserDataQueryable);
+            mockUserContext.Setup(m => m.Users).Returns(MockUserSet.Object);
             mockUserContext.Setup(m => m.EnsureCreatedAsync()).Returns(Task.FromResult(true));
 
             mockElectionContext = new Mock<MoqTrueVoteDbContext>();
             mockElectionDataQueryable = MoqData.MockElectionData.AsQueryable();
-            mockElectionSet = DbMoqHelper.GetDbSet(mockElectionDataQueryable);
-            mockElectionContext.Setup(m => m.Elections).Returns(mockElectionSet.Object);
+            MockElectionSet = DbMoqHelper.GetDbSet(mockElectionDataQueryable);
+            mockElectionContext.Setup(m => m.Elections).Returns(MockElectionSet.Object);
             mockElectionContext.Setup(m => m.EnsureCreatedAsync()).Returns(Task.FromResult(true));
 
             mockBallotContext = new Mock<MoqTrueVoteDbContext>();
             mockBallotDataQueryable = MoqData.MockBallotData.AsQueryable();
-            mockBallotSet = DbMoqHelper.GetDbSet(mockBallotDataQueryable);
-            mockBallotContext.Setup(m => m.Ballots).Returns(mockBallotSet.Object);
+            MockBallotSet = DbMoqHelper.GetDbSet(mockBallotDataQueryable);
+            mockBallotContext.Setup(m => m.Ballots).Returns(MockBallotSet.Object);
             mockBallotContext.Setup(m => m.EnsureCreatedAsync()).Returns(Task.FromResult(true));
 
             mockCandidateContext = new Mock<MoqTrueVoteDbContext>();
             mockCandidateDataQueryable = MoqData.MockCandidateData.AsQueryable();
             mockCandidateDataCollection = MoqData.MockCandidateData;
-            mockCandidateSet = DbMoqHelper.GetDbSet(mockCandidateDataQueryable);
-            mockCandidateContext.Setup(m => m.Candidates).Returns(mockCandidateSet.Object);
+            MockCandidateSet = DbMoqHelper.GetDbSet(mockCandidateDataQueryable);
+            mockCandidateContext.Setup(m => m.Candidates).Returns(MockCandidateSet.Object);
             mockCandidateContext.Setup(m => m.EnsureCreatedAsync()).Returns(Task.FromResult(true));
 
             mockTimestampContext = new Mock<MoqTrueVoteDbContext>();
             mockTimestampDataQueryable = MoqData.MockTimestampData.AsQueryable();
             mockTimestampDataCollection = MoqData.MockTimestampData;
-            mockTimestampSet = DbMoqHelper.GetDbSet(mockTimestampDataQueryable);
-            mockTimestampContext.Setup(m => m.Timestamps).Returns(mockTimestampSet.Object);
+            MockTimestampSet = DbMoqHelper.GetDbSet(mockTimestampDataQueryable);
+            mockTimestampContext.Setup(m => m.Timestamps).Returns(MockTimestampSet.Object);
             mockTimestampContext.Setup(m => m.EnsureCreatedAsync()).Returns(Task.FromResult(true));
-            mockBallotContext.Setup(m => m.Timestamps).Returns(mockTimestampSet.Object);
+            mockBallotContext.Setup(m => m.Timestamps).Returns(MockTimestampSet.Object);
 
             mockRaceContext = new Mock<MoqTrueVoteDbContext>();
             MoqData.MockRaceData[0].RaceId = "1";
@@ -129,8 +129,8 @@ namespace TrueVote.Api.Tests
             MoqData.MockRaceData[2].RaceId = "3";
             mockRaceDataQueryable = MoqData.MockRaceData.AsQueryable();
             mockRaceDataCollection = MoqData.MockRaceData;
-            mockRaceSet = DbMoqHelper.GetDbSet(mockRaceDataQueryable);
-            mockRaceContext.Setup(m => m.Races).Returns(mockRaceSet.Object);
+            MockRaceSet = DbMoqHelper.GetDbSet(mockRaceDataQueryable);
+            mockRaceContext.Setup(m => m.Races).Returns(MockRaceSet.Object);
             mockRaceContext.Setup(m => m.EnsureCreatedAsync()).Returns(Task.FromResult(true));
         }
     }
@@ -151,12 +151,12 @@ namespace TrueVote.Api.Tests
         {
             _moqDataAccessor = new MoqDataAccessor();
 
-            Users = _moqDataAccessor.mockUserSet.Object;
-            Elections = _moqDataAccessor.mockElectionSet.Object;
-            Races = _moqDataAccessor.mockRaceSet.Object;
-            Candidates = _moqDataAccessor.mockCandidateSet.Object;
-            Ballots = _moqDataAccessor.mockBallotSet.Object;
-            Timestamps = _moqDataAccessor.mockTimestampSet.Object;
+            Users = _moqDataAccessor.MockUserSet.Object;
+            Elections = _moqDataAccessor.MockElectionSet.Object;
+            Races = _moqDataAccessor.MockRaceSet.Object;
+            Candidates = _moqDataAccessor.MockCandidateSet.Object;
+            Ballots = _moqDataAccessor.MockBallotSet.Object;
+            Timestamps = _moqDataAccessor.MockTimestampSet.Object;
         }
 
         public virtual async Task<bool> EnsureCreatedAsync()

--- a/TrueVote.Api.Tests/MoqData.cs
+++ b/TrueVote.Api.Tests/MoqData.cs
@@ -12,40 +12,43 @@ namespace TrueVote.Api.Tests
     public static class MoqData
     {
         public static DateTime startDate = DateTime.Parse("2023-02-25");
+        public static DateTime endDate = DateTime.Parse("2023-02-25").AddDays(30);
         public static DateTime createDate = DateTime.Parse("2022-12-17");
+        public static DateTime createDate2 = DateTime.Parse("2022-12-17").AddHours(1);
+        public static DateTime createDate3 = DateTime.Parse("2022-12-17").AddHours(2);
 
         public static List<UserModel> MockUserData => new()
         {
-            new UserModel { Email = "foo@foo.com", DateCreated = createDate, FirstName = "Foo", UserId = "1" },
-            new UserModel { Email = "foo2@bar.com", DateCreated = createDate.AddSeconds(1), FirstName = "Foo2", UserId = "2" },
-            new UserModel { Email = "boo@bar.com", DateCreated = createDate.AddSeconds(2), FirstName = "Boo", UserId = "3" }
+            new UserModel { UserId = "userid1", Email = "foo@foo.com", DateCreated = createDate, FirstName = "Foo" },
+            new UserModel { UserId = "userid2", Email = "foo2@bar.com", DateCreated = createDate2, FirstName = "Foo2" },
+            new UserModel { UserId = "userid3", Email = "boo@bar.com", DateCreated = createDate3, FirstName = "Boo" }
         };
 
         public static List<ElectionModel> MockElectionData => new()
         {
-            new ElectionModel { Name = "California State", DateCreated = createDate, StartDate = startDate, EndDate = startDate.AddDays(30) },
-            new ElectionModel { Name = "Los Angeles County", DateCreated = createDate.AddSeconds(1), StartDate = startDate, EndDate = startDate.AddDays(30) },
-            new ElectionModel { Name = "Federal", DateCreated = createDate.AddSeconds(1), StartDate = startDate, EndDate = startDate.AddDays(30), ElectionId = "68" },
+            new ElectionModel { ElectionId = "electionid1", Name = "California State", DateCreated = createDate, StartDate = startDate, EndDate = endDate },
+            new ElectionModel { ElectionId = "electionid2", Name = "Los Angeles County", DateCreated = createDate2, StartDate = startDate, EndDate = endDate },
+            new ElectionModel { ElectionId = "electionid3", Name = "Federal", DateCreated = createDate3, StartDate = startDate, EndDate = endDate },
         };
 
         public static List<BallotModel> MockBallotData => new()
         {
-            new BallotModel { BallotId = "ballotid1", ElectionId = "68", Election = MockElectionData[0] },
-            new BallotModel { BallotId = "ballotid2", ElectionId = "68", Election = MockElectionData[1] },
-            new BallotModel { BallotId = "ballotid3", ElectionId = "68", Election = MockElectionData[2] },
+            new BallotModel { BallotId = "ballotid1", DateCreated = createDate, ElectionId = "electionid1", Election = MockElectionData[0] },
+            new BallotModel { BallotId = "ballotid2", DateCreated = createDate2, ElectionId = "electionid1", Election = MockElectionData[0] },
+            new BallotModel { BallotId = "ballotid3", DateCreated = createDate3, ElectionId = "electionid1", Election = MockElectionData[0] },
         };
 
         public static List<CandidateModel> MockCandidateData => new()
         {
-            new CandidateModel { Name = "John Smith", DateCreated = createDate, PartyAffiliation = "Republican", CandidateId =  "1" },
-            new CandidateModel { Name = "Jane Doe", DateCreated = createDate.AddSeconds(1), PartyAffiliation = "Democrat", CandidateId = "2" }
+            new CandidateModel { CandidateId = "candidateid1", Name = "John Smith", DateCreated = createDate, PartyAffiliation = "Republican" },
+            new CandidateModel { CandidateId = "candidateid2", Name = "Jane Doe", DateCreated = createDate2, PartyAffiliation = "Democrat" }
         };
 
         public static List<RaceModel> MockRaceData => new()
         {
-            new RaceModel { Name = "President", DateCreated = createDate, RaceType = RaceTypes.ChooseOne, RaceId = "1" },
-            new RaceModel { Name = "Judge", DateCreated = createDate.AddSeconds(1), RaceType = RaceTypes.ChooseMany, RaceId = "2" },
-            new RaceModel { Name = "Governor", DateCreated = createDate.AddSeconds(2), RaceType = RaceTypes.ChooseOne, RaceId = "3" }
+            new RaceModel { RaceId = "raceid1", Name = "President", DateCreated = createDate, RaceType = RaceTypes.ChooseOne },
+            new RaceModel { RaceId = "raceid2", Name = "Judge", DateCreated = createDate2, RaceType = RaceTypes.ChooseMany },
+            new RaceModel { RaceId = "raceid3", Name = "Governor", DateCreated = createDate3, RaceType = RaceTypes.ChooseOne }
         };
     }
 

--- a/TrueVote.Api.Tests/MoqData.cs
+++ b/TrueVote.Api.Tests/MoqData.cs
@@ -56,7 +56,6 @@ namespace TrueVote.Api.Tests
             new TimestampModel { TimestampId = "1", TimestampHashS = "SampleHash1", DateCreated = new DateTime(2023, 01, 01, 11, 11, 11) },
             new TimestampModel { TimestampId = "2", TimestampHashS = "SampleHash2", DateCreated = new DateTime(2023, 01, 01, 11, 11, 21) }
         };
-
     }
 
     public class MoqDataAccessor

--- a/TrueVote.Api.Tests/MoqData.cs
+++ b/TrueVote.Api.Tests/MoqData.cs
@@ -11,18 +11,21 @@ namespace TrueVote.Api.Tests
 {
     public static class MoqData
     {
+        public static DateTime startDate = DateTime.Parse("2023-02-25");
+        public static DateTime createDate = DateTime.Parse("2022-12-17");
+
         public static List<UserModel> MockUserData => new()
         {
-            new UserModel { Email = "foo@foo.com", DateCreated = DateTime.Now, FirstName = "Foo", UserId = "1" },
-            new UserModel { Email = "foo2@bar.com", DateCreated = DateTime.Now.AddSeconds(1), FirstName = "Foo2", UserId = "2" },
-            new UserModel { Email = "boo@bar.com", DateCreated = DateTime.Now.AddSeconds(2), FirstName = "Boo", UserId = "3" }
+            new UserModel { Email = "foo@foo.com", DateCreated = createDate, FirstName = "Foo", UserId = "1" },
+            new UserModel { Email = "foo2@bar.com", DateCreated = createDate.AddSeconds(1), FirstName = "Foo2", UserId = "2" },
+            new UserModel { Email = "boo@bar.com", DateCreated = createDate.AddSeconds(2), FirstName = "Boo", UserId = "3" }
         };
 
         public static List<ElectionModel> MockElectionData => new()
         {
-            new ElectionModel { Name = "California State", DateCreated = DateTime.Now },
-            new ElectionModel { Name = "Los Angeles County", DateCreated = DateTime.Now.AddSeconds(1), StartDate = DateTime.Now, EndDate = DateTime.Now.AddDays(30) },
-            new ElectionModel { Name = "Federal", DateCreated = DateTime.Now.AddSeconds(1), StartDate = DateTime.Now, EndDate = DateTime.Now.AddDays(30), ElectionId = "68" },
+            new ElectionModel { Name = "California State", DateCreated = createDate, StartDate = startDate, EndDate = startDate.AddDays(30) },
+            new ElectionModel { Name = "Los Angeles County", DateCreated = createDate.AddSeconds(1), StartDate = startDate, EndDate = startDate.AddDays(30) },
+            new ElectionModel { Name = "Federal", DateCreated = createDate.AddSeconds(1), StartDate = startDate, EndDate = startDate.AddDays(30), ElectionId = "68" },
         };
 
         public static List<BallotModel> MockBallotData => new()
@@ -34,15 +37,15 @@ namespace TrueVote.Api.Tests
 
         public static List<CandidateModel> MockCandidateData => new()
         {
-            new CandidateModel { Name = "John Smith", DateCreated = DateTime.Now, PartyAffiliation = "Republican", CandidateId =  "1" },
-            new CandidateModel { Name = "Jane Doe", DateCreated = DateTime.Now.AddSeconds(1), PartyAffiliation = "Democrat", CandidateId = "2" }
+            new CandidateModel { Name = "John Smith", DateCreated = createDate, PartyAffiliation = "Republican", CandidateId =  "1" },
+            new CandidateModel { Name = "Jane Doe", DateCreated = createDate.AddSeconds(1), PartyAffiliation = "Democrat", CandidateId = "2" }
         };
 
         public static List<RaceModel> MockRaceData => new()
         {
-            new RaceModel { Name = "President", DateCreated = DateTime.Now, RaceType = RaceTypes.ChooseOne, RaceId = "1" },
-            new RaceModel { Name = "Judge", DateCreated = DateTime.Now.AddSeconds(1), RaceType = RaceTypes.ChooseMany, RaceId = "2" },
-            new RaceModel { Name = "Governor", DateCreated = DateTime.Now.AddSeconds(2), RaceType = RaceTypes.ChooseOne, RaceId = "3" }
+            new RaceModel { Name = "President", DateCreated = createDate, RaceType = RaceTypes.ChooseOne, RaceId = "1" },
+            new RaceModel { Name = "Judge", DateCreated = createDate.AddSeconds(1), RaceType = RaceTypes.ChooseMany, RaceId = "2" },
+            new RaceModel { Name = "Governor", DateCreated = createDate.AddSeconds(2), RaceType = RaceTypes.ChooseOne, RaceId = "3" }
         };
     }
 

--- a/TrueVote.Api.Tests/ServiceTests/BallotTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/BallotTest.cs
@@ -100,7 +100,7 @@ namespace TrueVote.Api.Tests.ServiceTests
             Assert.NotEmpty(val);
             Assert.Single(val);
             Assert.Equal("ballotid3", val[0].BallotId);
-            Assert.Equal("68", val[0].ElectionId);
+            Assert.Equal("electionid1", val[0].ElectionId);
 
             _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
             _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));

--- a/TrueVote.Api.Tests/ServiceTests/BallotTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/BallotTest.cs
@@ -160,6 +160,5 @@ namespace TrueVote.Api.Tests.ServiceTests
             _logHelper.Verify(LogLevel.Error, Times.Exactly(1));
             _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
         }
-
     }
 }

--- a/TrueVote.Api.Tests/ServiceTests/BallotTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/BallotTest.cs
@@ -123,5 +123,43 @@ namespace TrueVote.Api.Tests.ServiceTests
             _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
             _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
         }
+
+        [Fact]
+        public async Task CountsBallots()
+        {
+            var countBallotsObj = new CountBallotModel { DateCreatedStart = new DateTime(2022, 01, 01), DateCreatedEnd = new DateTime(2033, 12, 31) };
+            var byteArray = Encoding.ASCII.GetBytes(JsonConvert.SerializeObject(countBallotsObj));
+            _httpContext.Request.Body = new MemoryStream(byteArray);
+
+            var ballotApi = new Ballot(_logHelper.Object, _moqDataAccessor.mockBallotContext.Object, _mockTelegram.Object);
+
+            var ret = await ballotApi.BallotCount(_httpContext.Request);
+            Assert.NotNull(ret);
+            var objectResult = Assert.IsType<OkObjectResult>(ret);
+            Assert.Equal((int) HttpStatusCode.OK, objectResult.StatusCode);
+
+            var val = objectResult.Value;
+            Assert.Equal(3, val);
+
+            _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
+            _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task HandlesCountBallotsError()
+        {
+            var countBallotsObj = "blah";
+            var byteArray = Encoding.ASCII.GetBytes(countBallotsObj);
+            _httpContext.Request.Body = new MemoryStream(byteArray);
+
+            var ret = await _ballotApi.BallotCount(_httpContext.Request);
+            Assert.NotNull(ret);
+            var objectResult = Assert.IsType<BadRequestObjectResult>(ret);
+            Assert.Equal((int) HttpStatusCode.BadRequest, objectResult.StatusCode);
+
+            _logHelper.Verify(LogLevel.Error, Times.Exactly(1));
+            _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
+        }
+
     }
 }

--- a/TrueVote.Api.Tests/ServiceTests/ElectionTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/ElectionTest.cs
@@ -275,8 +275,8 @@ namespace TrueVote.Api.Tests.ServiceTests
             var addsRacesElectionData = MoqData.MockElectionData;
 
             addsRacesElectionData[0].Races = _moqDataAccessor.mockRaceDataCollection;
-            addsRacesElectionData[0].ElectionId = "1";
-            addsRacesElectionData[1].ElectionId = "2";
+            addsRacesElectionData[0].ElectionId = "electionid1";
+            addsRacesElectionData[1].ElectionId = "electionid2";
 
             var mockElectionContext = new Mock<TrueVoteDbContext>();
 
@@ -286,7 +286,7 @@ namespace TrueVote.Api.Tests.ServiceTests
             var mockRacesSet = _moqDataAccessor.mockRaceDataCollection.AsQueryable().BuildMockDbSet();
             mockElectionContext.Setup(m => m.Races).Returns(mockRacesSet.Object);
 
-            var addRacesObj = new AddRacesModel { ElectionId = "1", RaceIds = new List<string> { "1", "2", "3" } };
+            var addRacesObj = new AddRacesModel { ElectionId = "electionid1", RaceIds = new List<string> { "raceid1", "raceid2", "raceid3" } };
             var byteArray = Encoding.ASCII.GetBytes(JsonConvert.SerializeObject(addRacesObj));
             _httpContext.Request.Body = new MemoryStream(byteArray);
 

--- a/TrueVote.Api.Tests/ServiceTests/Error500Test.cs
+++ b/TrueVote.Api.Tests/ServiceTests/Error500Test.cs
@@ -43,6 +43,7 @@ namespace TrueVote.Api.Tests.ServiceTests
             try
             {
                 _ = await error500.ThrowError500(_httpContext.Request);
+                Assert.True(false);
             }
             catch (Exception ex)
             {

--- a/TrueVote.Api.Tests/ServiceTests/GraphQLTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/GraphQLTest.cs
@@ -132,7 +132,7 @@ namespace TrueVote.Api.Tests.ServiceTests
         [Fact]
         public async Task RunsElectionByIdQuery()
         {
-            var electionId = "68";
+            var electionId = "electionid3";
 
             var graphQLRequest = new GraphQLRequest
             {
@@ -154,7 +154,7 @@ namespace TrueVote.Api.Tests.ServiceTests
             var elections = JsonConvert.DeserializeObject<List<ElectionModelResponse>>(JsonConvert.SerializeObject(graphQLRoot.GetElectionById));
             Assert.NotNull(elections);
             Assert.Equal("Federal", elections[0].Name);
-            Assert.Equal("68", elections[0].ElectionId);
+            Assert.Equal("electionid3", elections[0].ElectionId);
             Assert.True(elections.Count == 1);
 
             Assert.Equal((int) HttpStatusCode.OK, _httpContext.Response.StatusCode);
@@ -234,7 +234,7 @@ namespace TrueVote.Api.Tests.ServiceTests
             var graphQLRoot = await GraphQLQuerySetup(graphQLRequestJson);
 
             var ballots = JsonConvert.DeserializeObject<List<BallotModel>>(JsonConvert.SerializeObject(graphQLRoot.GetBallot));
-            Assert.Equal("68", ballots[0].ElectionId);
+            Assert.Equal("electionid1", ballots[0].ElectionId);
             Assert.Equal("ballotid3", ballots[0].BallotId);
             Assert.True(ballots.Count == 3);
 
@@ -266,7 +266,7 @@ namespace TrueVote.Api.Tests.ServiceTests
 
             var ballots = JsonConvert.DeserializeObject<List<BallotModel>>(JsonConvert.SerializeObject(graphQLRoot.GetBallotById));
             Assert.NotNull(ballots);
-            Assert.Equal("68", ballots[0].ElectionId);
+            Assert.Equal("electionid1", ballots[0].ElectionId);
             Assert.Equal("ballotid3", ballots[0].BallotId);
             Assert.True(ballots.Count == 1);
 

--- a/TrueVote.Api.Tests/ServiceTests/RaceTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/RaceTest.cs
@@ -182,7 +182,7 @@ namespace TrueVote.Api.Tests.ServiceTests
             var mockCandidatesSet = MoqData.MockCandidateData.AsQueryable().BuildMockDbSet();
             mockRaceContext.Setup(m => m.Candidates).Returns(mockCandidatesSet.Object);
 
-            var addCandidatesObj = new AddCandidatesModel { RaceId = "1", CandidateIds = new List<string> { MoqData.MockCandidateData[0].CandidateId, MoqData.MockCandidateData[1].CandidateId } };
+            var addCandidatesObj = new AddCandidatesModel { RaceId = "raceid1", CandidateIds = new List<string> { MoqData.MockCandidateData[0].CandidateId, MoqData.MockCandidateData[1].CandidateId } };
             var byteArray = Encoding.ASCII.GetBytes(JsonConvert.SerializeObject(addCandidatesObj));
             _httpContext.Request.Body = new MemoryStream(byteArray);
 
@@ -261,7 +261,7 @@ namespace TrueVote.Api.Tests.ServiceTests
             var mockCandidatesSet = _moqDataAccessor.mockCandidateDataQueryable.AsQueryable().BuildMockDbSet();
             mockRaceContext.Setup(m => m.Candidates).Returns(mockCandidatesSet.Object);
 
-            var addCandidatesObj = new AddCandidatesModel { RaceId = "1", CandidateIds = new List<string> { "68", "69" } };
+            var addCandidatesObj = new AddCandidatesModel { RaceId = "raceid1", CandidateIds = new List<string> { "68", "69" } };
             var byteArray = Encoding.ASCII.GetBytes(JsonConvert.SerializeObject(addCandidatesObj));
             _httpContext.Request.Body = new MemoryStream(byteArray);
 
@@ -291,7 +291,7 @@ namespace TrueVote.Api.Tests.ServiceTests
             var mockCandidatesSet = _moqDataAccessor.mockCandidateDataQueryable.AsQueryable().BuildMockDbSet();
             mockRaceContext.Setup(m => m.Candidates).Returns(mockCandidatesSet.Object);
 
-            var addCandidatesObj = new AddCandidatesModel { RaceId = "1", CandidateIds = new List<string> { "1", "2" } };
+            var addCandidatesObj = new AddCandidatesModel { RaceId = "raceid1", CandidateIds = new List<string> { "candidateid1", "candidateid2" } };
             var byteArray = Encoding.ASCII.GetBytes(JsonConvert.SerializeObject(addCandidatesObj));
             _httpContext.Request.Body = new MemoryStream(byteArray);
 

--- a/TrueVote.Api.Tests/ServiceTests/TimestampTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/TimestampTest.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Net;
+using System.Text;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using TrueVote.Api.Models;
+using TrueVote.Api.Tests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TrueVote.Api.Tests.Services
+{
+    public class TimestampTest : TestHelper
+    {
+        public TimestampTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public async Task FindsTimestamp()
+        {
+            var findTimestampObj = new FindTimestampModel { DateCreatedStart = new DateTime(2022, 01, 01), DateCreatedEnd = new DateTime(2024, 01, 01) };
+            var byteArray = Encoding.ASCII.GetBytes(JsonConvert.SerializeObject(findTimestampObj));
+            _httpContext.Request.Body = new MemoryStream(byteArray);
+
+            var ret = await _timestampApi.TimestampFind(_httpContext.Request);
+            Assert.NotNull(ret);
+            var objectResult = Assert.IsType<OkObjectResult>(ret);
+            Assert.Equal((int) HttpStatusCode.OK, objectResult.StatusCode);
+
+            var val = objectResult.Value as List<TimestampModel>;
+            Assert.NotEmpty(val);
+            Assert.Equal(2, val.Count);
+            Assert.Equal("2", val[0].TimestampId);
+            Assert.Equal("SampleHash2", val[0].TimestampHashS);
+
+            _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
+            _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task HandlesFindTimestampError()
+        {
+            var findTimestampObj = "blah";
+            var byteArray = Encoding.ASCII.GetBytes(findTimestampObj);
+            _httpContext.Request.Body = new MemoryStream(byteArray);
+
+            var ret = await _timestampApi.TimestampFind(_httpContext.Request);
+            Assert.NotNull(ret);
+            var objectResult = Assert.IsType<BadRequestObjectResult>(ret);
+            Assert.Equal((int) HttpStatusCode.BadRequest, objectResult.StatusCode);
+
+            _logHelper.Verify(LogLevel.Error, Times.Exactly(1));
+            _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task HandlesUnfoundTimestamp()
+        {
+            var findTimestampObj = new FindTimestampModel { DateCreatedStart = new DateTime(2021, 01, 01), DateCreatedEnd = new DateTime(2022, 01, 01) };
+            var byteArray = Encoding.ASCII.GetBytes(JsonConvert.SerializeObject(findTimestampObj));
+            _httpContext.Request.Body = new MemoryStream(byteArray);
+
+            var ret = await _timestampApi.TimestampFind(_httpContext.Request);
+            Assert.NotNull(ret);
+            var objectResult = Assert.IsType<NotFoundResult>(ret);
+            Assert.Equal((int) HttpStatusCode.NotFound, objectResult.StatusCode);
+
+            _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
+            _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
+        }
+    }
+}

--- a/TrueVote.Api.Tests/ServiceTests/ValidatorTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/ValidatorTest.cs
@@ -3,8 +3,7 @@ using Microsoft.Azure.WebJobs.Extensions.Timers;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NCrontab;
-using System.Text;
-using TrueVote.Api.Services;
+using System.Threading.Tasks;
 using TrueVote.Api.Tests.Helpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -25,15 +24,15 @@ namespace TrueVote.Api.Tests.ServiceTests
             var status = new ScheduleStatus();
             var timerInfo = new TimerInfo(cronSchedule, status);
 
-            _validatorApi.Run(timerInfo);
+            _ = _validatorApi.Run(timerInfo);
 
             _logHelper.Verify(LogLevel.Information, Times.AtLeast(1));
         }
 
         [Fact]
-        public void HashesBallotData()
+        public async Task HashesBallotDataAsync()
         {
-            var timestamp = _validatorApi.HashBallotsAsync();
+            var timestamp = await _validatorApi.HashBallotsAsync();
 
             Assert.NotNull(timestamp);
             Assert.Equal(50, timestamp.MerkleRoot[0]);

--- a/TrueVote.Api.Tests/ServiceTests/ValidatorTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/ValidatorTest.cs
@@ -3,7 +3,11 @@ using Microsoft.Azure.WebJobs.Extensions.Timers;
 using Microsoft.Extensions.Logging;
 using Moq;
 using NCrontab;
+using System;
+using System.Linq;
 using System.Threading.Tasks;
+using TrueVote.Api.Helpers;
+using TrueVote.Api.Services;
 using TrueVote.Api.Tests.Helpers;
 using Xunit;
 using Xunit.Abstractions;
@@ -36,6 +40,51 @@ namespace TrueVote.Api.Tests.ServiceTests
 
             Assert.NotNull(timestamp);
             Assert.Equal(50, timestamp.MerkleRoot[0]);
+        }
+
+        [Fact]
+        public async Task HashesBallotThrowsStampingError()
+        {
+            var mockOpenTimestampsClient = new Mock<IOpenTimestampsClient>();
+            mockOpenTimestampsClient.Setup(m => m.Stamp(It.IsAny<byte[]>())).Throws(new Exception("Stamp exception"));
+
+            var validatorApi = new Validator(_logHelper.Object, _moqDataAccessor.mockBallotContext.Object, _mockTelegram.Object, mockOpenTimestampsClient.Object);
+
+            try
+            {
+                var timestamp = await validatorApi.HashBallotsAsync();
+                Assert.True(false);
+            }
+            catch (Exception ex)
+            {
+                _output.WriteLine($"{ex}");
+                Assert.NotNull(ex);
+                Assert.Contains("Stamp exception", ex.Message);
+            }
+        }
+
+        [Fact]
+        public async Task HashesBallotThrowsStoreTimestampException()
+        {
+            var mockBallotContext = new Mock<MoqTrueVoteDbContext>();
+            var mockBallotDataQueryable = MoqData.MockBallotData.AsQueryable();
+            var MockBallotSet = DbMoqHelper.GetDbSet(mockBallotDataQueryable);
+            mockBallotContext.Setup(m => m.Ballots).Returns(MockBallotSet.Object);
+            mockBallotContext.Setup(m => m.EnsureCreatedAsync()).Throws(new Exception("Storing data exception"));
+
+            var validatorApi = new Validator(_logHelper.Object, mockBallotContext.Object, _mockTelegram.Object, _mockOpenTimestampsClient.Object);
+
+            try
+            {
+                var timestamp = await validatorApi.HashBallotsAsync();
+                Assert.True(false);
+            }
+            catch (Exception ex)
+            {
+                _output.WriteLine($"{ex}");
+                Assert.NotNull(ex);
+                Assert.Contains("Storing data exception", ex.Message);
+            }
         }
     }
 }

--- a/TrueVote.Api.Tests/ServiceTests/ValidatorTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/ValidatorTest.cs
@@ -36,7 +36,7 @@ namespace TrueVote.Api.Tests.ServiceTests
             var timestamp = _validatorApi.HashBallots();
 
             Assert.NotNull(timestamp);
-            // Assert.Equal(66, timestamp.MerkleRoot[0]);
+            Assert.Equal(50, timestamp.MerkleRoot[0]);
         }
     }
 }

--- a/TrueVote.Api.Tests/ServiceTests/ValidatorTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/ValidatorTest.cs
@@ -33,7 +33,7 @@ namespace TrueVote.Api.Tests.ServiceTests
         [Fact]
         public void HashesBallotData()
         {
-            var timestamp = _validatorApi.HashBallots();
+            var timestamp = _validatorApi.HashBallotsAsync();
 
             Assert.NotNull(timestamp);
             Assert.Equal(50, timestamp.MerkleRoot[0]);

--- a/TrueVote.Api.Tests/ServiceTests/ValidatorTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/ValidatorTest.cs
@@ -1,0 +1,42 @@
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Timers;
+using Microsoft.Extensions.Logging;
+using Moq;
+using NCrontab;
+using System.Text;
+using TrueVote.Api.Services;
+using TrueVote.Api.Tests.Helpers;
+using Xunit;
+using Xunit.Abstractions;
+
+namespace TrueVote.Api.Tests.ServiceTests
+{
+    public class ValidatorTest : TestHelper
+    {
+        public ValidatorTest(ITestOutputHelper output) : base(output)
+        {
+        }
+
+        [Fact]
+        public void CallsValidator()
+        {
+            var cronSchedule = new CronSchedule(CrontabSchedule.Parse("*/5 * * * *"));
+
+            var status = new ScheduleStatus();
+            var timerInfo = new TimerInfo(cronSchedule, status);
+
+            _validatorApi.Run(timerInfo);
+
+            _logHelper.Verify(LogLevel.Information, Times.AtLeast(1));
+        }
+
+        [Fact]
+        public void HashesBallotData()
+        {
+            var timestamp = _validatorApi.HashBallots();
+
+            Assert.NotNull(timestamp);
+            // Assert.Equal(66, timestamp.MerkleRoot[0]);
+        }
+    }
+}

--- a/TrueVote.Api.Tests/ServiceTests/ValidatorTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/ValidatorTest.cs
@@ -21,19 +21,6 @@ namespace TrueVote.Api.Tests.ServiceTests
         }
 
         [Fact]
-        public void CallsValidator()
-        {
-            var cronSchedule = new CronSchedule(CrontabSchedule.Parse("*/5 * * * *"));
-
-            var status = new ScheduleStatus();
-            var timerInfo = new TimerInfo(cronSchedule, status);
-
-            _ = _validatorApi.Run(timerInfo);
-
-            _logHelper.Verify(LogLevel.Information, Times.AtLeast(1));
-        }
-
-        [Fact]
         public async Task HashesBallotDataAsync()
         {
             var timestamp = await _validatorApi.HashBallotsAsync();

--- a/TrueVote.Api/Helpers/Extensions.cs
+++ b/TrueVote.Api/Helpers/Extensions.cs
@@ -1,5 +1,6 @@
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
+using System.Text.RegularExpressions;
 
 namespace TrueVote.Api
 {
@@ -9,6 +10,21 @@ namespace TrueVote.Api
         public static string ToTitleCase(this string @this)
         {
             return new CultureInfo("en-US").TextInfo.ToTitleCase(@this);
+        }
+
+        public static string ExtractUrl(this string @this)
+        {
+            // Define the regular expression pattern
+            var pattern = @"https?://\S+$";
+
+            // Create a Regex object with the pattern
+            var regex = new Regex(pattern);
+
+            // Match the pattern against the input string
+            var match = regex.Match(@this);
+
+            // Check if a match is found
+            return match.Success ? match.Value : string.Empty;
         }
     }
 }

--- a/TrueVote.Api/Helpers/MerkleTree.cs
+++ b/TrueVote.Api/Helpers/MerkleTree.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Buffers;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using Utf8Json;
+
+namespace TrueVote.Api.Helpers
+{
+    public static class MerkleTree
+    {
+        private static readonly SHA256 s_sha256 = SHA256.Create();
+        private static readonly ArrayPool<byte> s_bytePool = ArrayPool<byte>.Shared;
+
+        public static byte[] CalculateMerkleRoot<T>(List<T> data)
+        {
+            if (data == null || data.Count == 0)
+            {
+                return null;
+            }
+
+            if (data.Count == 1)
+            {
+                return GetHash(data[0]);
+            }
+
+            var leafNodes = data.Select(GetHash).ToList();
+
+            while (leafNodes.Count > 1)
+            {
+                var parentNodes = new List<byte[]>();
+                for (var i = 0; i < leafNodes.Count; i += 2)
+                {
+                    var left = leafNodes[i];
+                    var right = (i + 1 < leafNodes.Count) ? leafNodes[i + 1] : left;
+
+                    var parent = GetHash(left, right);
+                    parentNodes.Add(parent);
+                }
+                leafNodes = parentNodes;
+            }
+
+            return leafNodes[0];
+        }
+
+        public static byte[] GetHash<T>(T value)
+        {
+            var serializer = JsonSerializer.Serialize(value);
+            return s_sha256.ComputeHash(serializer);
+        }
+
+        public static byte[] GetHash(byte[] left, byte[] right)
+        {
+            var buffer = s_bytePool.Rent(left.Length + right.Length);
+            try
+            {
+                left.AsSpan().CopyTo(buffer);
+                right.AsSpan().CopyTo(buffer.AsSpan(left.Length));
+
+                return s_sha256.ComputeHash(buffer.AsSpan(0, left.Length + right.Length).ToArray());
+            }
+            finally
+            {
+                s_bytePool.Return(buffer);
+            }
+        }
+    }
+}

--- a/TrueVote.Api/Helpers/MerkleTree.cs
+++ b/TrueVote.Api/Helpers/MerkleTree.cs
@@ -1,8 +1,14 @@
+using Microsoft.Azure.Cosmos.Core;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Serialization;
 using System;
 using System.Buffers;
 using System.Collections.Generic;
+using System.IO;
 using System.Linq;
 using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
 using Utf8Json;
 
 namespace TrueVote.Api.Helpers
@@ -45,7 +51,7 @@ namespace TrueVote.Api.Helpers
 
         public static byte[] GetHash<T>(T value)
         {
-            var serializer = JsonSerializer.Serialize(value);
+            var serializer = Utf8Json.JsonSerializer.Serialize(value);
             return s_sha256.ComputeHash(serializer);
         }
 

--- a/TrueVote.Api/Helpers/MerkleTree.cs
+++ b/TrueVote.Api/Helpers/MerkleTree.cs
@@ -18,6 +18,7 @@ namespace TrueVote.Api.Helpers
         private static readonly SHA256 s_sha256 = SHA256.Create();
         private static readonly ArrayPool<byte> s_bytePool = ArrayPool<byte>.Shared;
 
+        // Calculates the Merkle root hash from a list of data
         public static byte[] CalculateMerkleRoot<T>(List<T> data)
         {
             if (data == null || data.Count == 0)
@@ -30,8 +31,10 @@ namespace TrueVote.Api.Helpers
                 return GetHash(data[0]);
             }
 
+            // Convert each data item to its hash representation (leaf nodes)
             var leafNodes = data.Select(GetHash).ToList();
 
+            // Build the Merkle tree by computing parent nodes until only the root remains
             while (leafNodes.Count > 1)
             {
                 var parentNodes = new List<byte[]>();
@@ -49,12 +52,14 @@ namespace TrueVote.Api.Helpers
             return leafNodes[0];
         }
 
+        // Computes the hash of an object
         public static byte[] GetHash<T>(T value)
         {
             var serializer = Utf8Json.JsonSerializer.Serialize(value);
             return s_sha256.ComputeHash(serializer);
         }
 
+        // Computes the hash of the concatenation of two byte arrays
         public static byte[] GetHash(byte[] left, byte[] right)
         {
             var buffer = s_bytePool.Rent(left.Length + right.Length);

--- a/TrueVote.Api/Helpers/OpenTimestamps.cs
+++ b/TrueVote.Api/Helpers/OpenTimestamps.cs
@@ -9,7 +9,7 @@ namespace TrueVote.Api.Helpers
         Task<byte[]> Stamp(byte[] hash);
     }
 
-    public class OpenTimestampsClient: IOpenTimestampsClient
+    public class OpenTimestampsClient : IOpenTimestampsClient
     {
         private readonly Uri _uri;
         private readonly HttpClient _httpClient;
@@ -22,14 +22,21 @@ namespace TrueVote.Api.Helpers
 
         public async virtual Task<byte[]> Stamp(byte[] hash)
         {
+            // TODO Temp for debugging - remove next line:
+            return hash;
+
+            // Construct the request URI by combining the base URI with the "/digest" endpoint
             var requestUri = new Uri(_uri, "/digest");
 
             using var content = new ByteArrayContent(hash);
 
+            // Send a POST request to the specified URI with the hash as the request content
             var response = await _httpClient.PostAsync(requestUri, content).ConfigureAwait(false);
 
+            // Ensure the response has a successful status code
             response.EnsureSuccessStatusCode();
 
+            // Read the response content as byte array, representing the timestamp bytes
             var timestampBytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
 
             return timestampBytes;

--- a/TrueVote.Api/Helpers/OpenTimestamps.cs
+++ b/TrueVote.Api/Helpers/OpenTimestamps.cs
@@ -1,0 +1,38 @@
+using System;
+using System.Net.Http;
+using System.Threading.Tasks;
+
+namespace TrueVote.Api.Helpers
+{
+    public class OpenTimestampsClient : IDisposable
+    {
+        private readonly Uri _uri;
+        private readonly HttpClient _httpClient;
+
+        public OpenTimestampsClient(Uri uri)
+        {
+            _uri = uri;
+            _httpClient = new HttpClient();
+        }
+
+        public async Task<byte[]> Stamp(byte[] hash)
+        {
+            var requestUri = new Uri(_uri, "/digest");
+
+            using var content = new ByteArrayContent(hash);
+
+            var response = await _httpClient.PostAsync(requestUri, content).ConfigureAwait(false);
+
+            response.EnsureSuccessStatusCode();
+
+            var timestampBytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
+
+            return timestampBytes;
+        }
+
+        public void Dispose()
+        {
+            _httpClient.Dispose();
+        }
+    }
+}

--- a/TrueVote.Api/Helpers/OpenTimestamps.cs
+++ b/TrueVote.Api/Helpers/OpenTimestamps.cs
@@ -23,7 +23,7 @@ namespace TrueVote.Api.Helpers
         public async virtual Task<byte[]> Stamp(byte[] hash)
         {
             // TODO Temp for debugging - remove next line:
-            return hash;
+            // return hash;
 
             // Construct the request URI by combining the base URI with the "/digest" endpoint
             var requestUri = new Uri(_uri, "/digest");

--- a/TrueVote.Api/Helpers/OpenTimestamps.cs
+++ b/TrueVote.Api/Helpers/OpenTimestamps.cs
@@ -4,18 +4,23 @@ using System.Threading.Tasks;
 
 namespace TrueVote.Api.Helpers
 {
-    public class OpenTimestampsClient : IDisposable
+    public interface IOpenTimestampsClient
+    {
+        Task<byte[]> Stamp(byte[] hash);
+    }
+
+    public class OpenTimestampsClient: IOpenTimestampsClient
     {
         private readonly Uri _uri;
         private readonly HttpClient _httpClient;
 
-        public OpenTimestampsClient(Uri uri)
+        public OpenTimestampsClient(Uri uri, HttpClient httpClient)
         {
             _uri = uri;
-            _httpClient = new HttpClient();
+            _httpClient = httpClient;
         }
 
-        public async Task<byte[]> Stamp(byte[] hash)
+        public async virtual Task<byte[]> Stamp(byte[] hash)
         {
             var requestUri = new Uri(_uri, "/digest");
 
@@ -28,11 +33,6 @@ namespace TrueVote.Api.Helpers
             var timestampBytes = await response.Content.ReadAsByteArrayAsync().ConfigureAwait(false);
 
             return timestampBytes;
-        }
-
-        public void Dispose()
-        {
-            _httpClient.Dispose();
         }
     }
 }

--- a/TrueVote.Api/Interfaces/ITrueVoteDbContext.cs
+++ b/TrueVote.Api/Interfaces/ITrueVoteDbContext.cs
@@ -11,6 +11,7 @@ namespace TrueVote.Api.Interfaces
         DbSet<RaceModel> Races { get; set; }
         DbSet<CandidateModel> Candidates { get; set; }
         DbSet<BallotModel> Ballots { get; set; }
+        DbSet<TimestampModel> Timestamps { get; set; }
 
         Task<bool> EnsureCreatedAsync();
         Task<int> SaveChangesAsync();

--- a/TrueVote.Api/Models/BallotModel.cs
+++ b/TrueVote.Api/Models/BallotModel.cs
@@ -52,7 +52,7 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "ElectionId")]
         public string ElectionId { get; set; }
 
-        private DateTime _DateCreated;
+        private DateTime? _DateCreated = null;
 
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
@@ -61,7 +61,7 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "DateCreated")]
         public DateTime DateCreated
         {
-            get => _DateCreated = _DateCreated == DateTime.MinValue ? DateTime.UtcNow : _DateCreated;
+            get => _DateCreated ?? DateTime.UtcNow;
             set => _DateCreated = value;
         }
 

--- a/TrueVote.Api/Models/BallotModel.cs
+++ b/TrueVote.Api/Models/BallotModel.cs
@@ -1,5 +1,6 @@
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;
@@ -51,12 +52,18 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "ElectionId")]
         public string ElectionId { get; set; }
 
+        private DateTime _DateCreated;
+
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
         [MaxLength(2048)]
         [DataType(DataType.Date)]
         [JsonProperty(PropertyName = "DateCreated")]
-        public DateTime DateCreated { get; set; } = DateTime.UtcNow;
+        public DateTime DateCreated
+        {
+            get => _DateCreated = _DateCreated == DateTime.MinValue ? DateTime.UtcNow : _DateCreated;
+            set => _DateCreated = value;
+        }
 
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [MaxLength(2048)]

--- a/TrueVote.Api/Models/BallotModel.cs
+++ b/TrueVote.Api/Models/BallotModel.cs
@@ -32,6 +32,24 @@ namespace TrueVote.Api.Models
     }
 
     [ExcludeFromCodeCoverage]
+    public class CountBallotModel
+    {
+        [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
+        [OpenApiProperty(Description = "DateCreatedStart")]
+        [MaxLength(2048)]
+        [DataType(DataType.Date)]
+        [JsonProperty(PropertyName = "DateCreatedStart", Required = Required.Always)]
+        public DateTime DateCreatedStart { get; set; }
+
+        [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
+        [OpenApiProperty(Description = "DateCreatedEnd")]
+        [MaxLength(2048)]
+        [DataType(DataType.Date)]
+        [JsonProperty(PropertyName = "DateCreatedEnd", Required = Required.Always)]
+        public DateTime DateCreatedEnd { get; set; }
+    }
+
+    [ExcludeFromCodeCoverage]
     public class BallotModel
     {
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]

--- a/TrueVote.Api/Models/BallotModel.cs
+++ b/TrueVote.Api/Models/BallotModel.cs
@@ -52,18 +52,12 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "ElectionId")]
         public string ElectionId { get; set; }
 
-        private DateTime? _DateCreated = null;
-
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
         [MaxLength(2048)]
         [DataType(DataType.Date)]
         [JsonProperty(PropertyName = "DateCreated")]
-        public DateTime DateCreated
-        {
-            get => _DateCreated ?? DateTime.UtcNow;
-            set => _DateCreated = value;
-        }
+        public DateTime DateCreated { get; set; } = DateTime.UtcNow;
 
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [MaxLength(2048)]

--- a/TrueVote.Api/Models/BallotModel.cs
+++ b/TrueVote.Api/Models/BallotModel.cs
@@ -1,6 +1,5 @@
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
 using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
-using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Extensions;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Generic;

--- a/TrueVote.Api/Models/CandidateModel.cs
+++ b/TrueVote.Api/Models/CandidateModel.cs
@@ -93,12 +93,18 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "PartyAffiliation")]
         public string PartyAffiliation { get; set; } = string.Empty;
 
+        private DateTime _DateCreated;
+
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
         [MaxLength(2048)]
         [DataType(DataType.Date)]
         [JsonProperty(PropertyName = "DateCreated")]
-        public DateTime DateCreated { get; set; } = DateTime.UtcNow;
+        public DateTime DateCreated
+        {
+            get => _DateCreated = _DateCreated == DateTime.MinValue ? DateTime.UtcNow : _DateCreated;
+            set => _DateCreated = value;
+        }
 
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "Selected")]

--- a/TrueVote.Api/Models/CandidateModel.cs
+++ b/TrueVote.Api/Models/CandidateModel.cs
@@ -93,7 +93,7 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "PartyAffiliation")]
         public string PartyAffiliation { get; set; } = string.Empty;
 
-        private DateTime _DateCreated;
+        private DateTime? _DateCreated = null;
 
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
@@ -102,7 +102,7 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "DateCreated")]
         public DateTime DateCreated
         {
-            get => _DateCreated = _DateCreated == DateTime.MinValue ? DateTime.UtcNow : _DateCreated;
+            get => _DateCreated ?? DateTime.UtcNow;
             set => _DateCreated = value;
         }
 

--- a/TrueVote.Api/Models/CandidateModel.cs
+++ b/TrueVote.Api/Models/CandidateModel.cs
@@ -93,18 +93,12 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "PartyAffiliation")]
         public string PartyAffiliation { get; set; } = string.Empty;
 
-        private DateTime? _DateCreated = null;
-
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
         [MaxLength(2048)]
         [DataType(DataType.Date)]
         [JsonProperty(PropertyName = "DateCreated")]
-        public DateTime DateCreated
-        {
-            get => _DateCreated ?? DateTime.UtcNow;
-            set => _DateCreated = value;
-        }
+        public DateTime DateCreated { get; set; } = DateTime.UtcNow;
 
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "Selected")]

--- a/TrueVote.Api/Models/ElectionModel.cs
+++ b/TrueVote.Api/Models/ElectionModel.cs
@@ -139,12 +139,18 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "EndDate", Required = Required.Always)]
         public DateTime? EndDate { get; set; }
 
+        private DateTime _DateCreated;
+
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
         [MaxLength(2048)]
         [DataType(DataType.Date)]
         [JsonProperty(PropertyName = "DateCreated")]
-        public DateTime DateCreated { get; set; } = DateTime.UtcNow;
+        public DateTime DateCreated
+        {
+            get => _DateCreated = _DateCreated == DateTime.MinValue ? DateTime.UtcNow : _DateCreated;
+            set => _DateCreated = value;
+        }
 
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "List of Races")]
@@ -203,12 +209,18 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "EndDate")]
         public DateTime? EndDate { get; set; }
 
+        private DateTime _DateCreated;
+
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
         [MaxLength(2048)]
         [DataType(DataType.Date)]
         [JsonProperty(PropertyName = "DateCreated")]
-        public DateTime DateCreated { get; set; } = DateTime.UtcNow;
+        public DateTime DateCreated
+        {
+            get => _DateCreated = _DateCreated == DateTime.MinValue ? DateTime.UtcNow : _DateCreated;
+            set => _DateCreated = value;
+        }
 
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "List of Races")]

--- a/TrueVote.Api/Models/ElectionModel.cs
+++ b/TrueVote.Api/Models/ElectionModel.cs
@@ -139,18 +139,12 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "EndDate", Required = Required.Always)]
         public DateTime? EndDate { get; set; }
 
-        private DateTime? _DateCreated = null;
-
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
         [MaxLength(2048)]
         [DataType(DataType.Date)]
         [JsonProperty(PropertyName = "DateCreated")]
-        public DateTime DateCreated
-        {
-            get => _DateCreated ?? DateTime.UtcNow;
-            set => _DateCreated = value;
-        }
+        public DateTime DateCreated { get; set; } = DateTime.UtcNow;
 
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "List of Races")]
@@ -209,18 +203,13 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "EndDate")]
         public DateTime? EndDate { get; set; }
 
-        private DateTime? _DateCreated = null;
-
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
         [MaxLength(2048)]
         [DataType(DataType.Date)]
         [JsonProperty(PropertyName = "DateCreated")]
-        public DateTime DateCreated
-        {
-            get => _DateCreated ?? DateTime.UtcNow;
-            set => _DateCreated = value;
-        }
+        public DateTime DateCreated { get; set; } = DateTime.UtcNow;
+
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "List of Races")]
         [DataType("ICollection<RaceModel>")]

--- a/TrueVote.Api/Models/ElectionModel.cs
+++ b/TrueVote.Api/Models/ElectionModel.cs
@@ -139,7 +139,7 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "EndDate", Required = Required.Always)]
         public DateTime? EndDate { get; set; }
 
-        private DateTime _DateCreated;
+        private DateTime? _DateCreated = null;
 
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
@@ -148,7 +148,7 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "DateCreated")]
         public DateTime DateCreated
         {
-            get => _DateCreated = _DateCreated == DateTime.MinValue ? DateTime.UtcNow : _DateCreated;
+            get => _DateCreated ?? DateTime.UtcNow;
             set => _DateCreated = value;
         }
 
@@ -209,7 +209,7 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "EndDate")]
         public DateTime? EndDate { get; set; }
 
-        private DateTime _DateCreated;
+        private DateTime? _DateCreated = null;
 
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
@@ -218,10 +218,9 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "DateCreated")]
         public DateTime DateCreated
         {
-            get => _DateCreated = _DateCreated == DateTime.MinValue ? DateTime.UtcNow : _DateCreated;
+            get => _DateCreated ?? DateTime.UtcNow;
             set => _DateCreated = value;
         }
-
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "List of Races")]
         [DataType("ICollection<RaceModel>")]

--- a/TrueVote.Api/Models/RaceModel.cs
+++ b/TrueVote.Api/Models/RaceModel.cs
@@ -101,18 +101,12 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "RaceTypeName")]
         public string RaceTypeName => RaceType.ToString();
 
-        private DateTime? _DateCreated = null;
-
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
         [MaxLength(2048)]
         [DataType(DataType.Date)]
         [JsonProperty(PropertyName = "DateCreated")]
-        public DateTime DateCreated
-        {
-            get => _DateCreated ?? DateTime.UtcNow;
-            set => _DateCreated = value;
-        }
+        public DateTime DateCreated { get; set; } = DateTime.UtcNow;
 
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "List of Candidates")]
@@ -156,18 +150,13 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "RaceTypeName")]
         public string RaceTypeName => RaceType.ToString();
 
-        private DateTime? _DateCreated = null;
-
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
         [MaxLength(2048)]
         [DataType(DataType.Date)]
         [JsonProperty(PropertyName = "DateCreated")]
-        public DateTime DateCreated
-        {
-            get => _DateCreated ?? DateTime.UtcNow;
-            set => _DateCreated = value;
-        }
+        public DateTime DateCreated { get; set; } = DateTime.UtcNow;
+
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "List of Candidates")]
         [DataType("ICollection<CandidateModel>")]

--- a/TrueVote.Api/Models/RaceModel.cs
+++ b/TrueVote.Api/Models/RaceModel.cs
@@ -101,7 +101,7 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "RaceTypeName")]
         public string RaceTypeName => RaceType.ToString();
 
-        private DateTime _DateCreated;
+        private DateTime? _DateCreated = null;
 
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
@@ -110,7 +110,7 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "DateCreated")]
         public DateTime DateCreated
         {
-            get => _DateCreated = _DateCreated == DateTime.MinValue ? DateTime.UtcNow : _DateCreated;
+            get => _DateCreated ?? DateTime.UtcNow;
             set => _DateCreated = value;
         }
 
@@ -156,7 +156,7 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "RaceTypeName")]
         public string RaceTypeName => RaceType.ToString();
 
-        private DateTime _DateCreated;
+        private DateTime? _DateCreated = null;
 
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
@@ -165,10 +165,9 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "DateCreated")]
         public DateTime DateCreated
         {
-            get => _DateCreated = _DateCreated == DateTime.MinValue ? DateTime.UtcNow : _DateCreated;
+            get => _DateCreated ?? DateTime.UtcNow;
             set => _DateCreated = value;
         }
-
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "List of Candidates")]
         [DataType("ICollection<CandidateModel>")]

--- a/TrueVote.Api/Models/RaceModel.cs
+++ b/TrueVote.Api/Models/RaceModel.cs
@@ -101,12 +101,18 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "RaceTypeName")]
         public string RaceTypeName => RaceType.ToString();
 
+        private DateTime _DateCreated;
+
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
         [MaxLength(2048)]
         [DataType(DataType.Date)]
         [JsonProperty(PropertyName = "DateCreated")]
-        public DateTime DateCreated { get; set; } = DateTime.UtcNow;
+        public DateTime DateCreated
+        {
+            get => _DateCreated = _DateCreated == DateTime.MinValue ? DateTime.UtcNow : _DateCreated;
+            set => _DateCreated = value;
+        }
 
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "List of Candidates")]
@@ -150,12 +156,18 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "RaceTypeName")]
         public string RaceTypeName => RaceType.ToString();
 
+        private DateTime _DateCreated;
+
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
         [MaxLength(2048)]
         [DataType(DataType.Date)]
         [JsonProperty(PropertyName = "DateCreated")]
-        public DateTime DateCreated { get; set; } = DateTime.UtcNow;
+        public DateTime DateCreated
+        {
+            get => _DateCreated = _DateCreated == DateTime.MinValue ? DateTime.UtcNow : _DateCreated;
+            set => _DateCreated = value;
+        }
 
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "List of Candidates")]

--- a/TrueVote.Api/Models/TimestampModel.cs
+++ b/TrueVote.Api/Models/TimestampModel.cs
@@ -1,0 +1,84 @@
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.EntityFrameworkCore.Metadata.Internal;
+using Newtonsoft.Json;
+using System;
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+using System.Diagnostics.CodeAnalysis;
+
+namespace TrueVote.Api.Models
+{
+    [ExcludeFromCodeCoverage]
+    public class TimestampModel
+    {
+        [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
+        [OpenApiProperty(Description = "Timestamp Id")]
+        [MaxLength(2048)]
+        [DataType(DataType.Text)]
+        [RegularExpression(Constants.GenericStringRegex)]
+        [JsonProperty(PropertyName = "TimestampId")]
+        [Key]
+        public string TimestampId { get; set; } = Guid.NewGuid().ToString();
+
+        [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
+        [OpenApiProperty(Description = "MerkleRoot")]
+        [DataType(DataType.Custom)]
+        [JsonProperty(PropertyName = "MerkleRoot")]
+        public byte[] MerkleRoot { get; set; }
+
+        [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
+        [OpenApiProperty(Description = "MerkleRootHash")]
+        [DataType(DataType.Custom)]
+        [JsonProperty(PropertyName = "MerkleRootHash")]
+        public byte[] MerkleRootHash { get; set; }
+
+        [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
+        [OpenApiProperty(Description = "TimestampHash")]
+        [DataType(DataType.Custom)]
+        [JsonProperty(PropertyName = "TimestampHash")]
+        public byte[] TimestampHash { get; set; }
+
+        [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
+        [OpenApiProperty(Description = "TimestampHash String")]
+        [MaxLength(2048)]
+        [DataType(DataType.Text)]
+        [RegularExpression(Constants.GenericStringRegex)]
+        [JsonProperty(PropertyName = "TimestampHashS")]
+        public string TimestampHashS { get; set; }
+
+        public DateTime TimestampAt { get; set; }
+
+        [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
+        [OpenApiProperty(Description = "CalendarServerUrl")]
+        [MaxLength(2048)]
+        [DataType(DataType.Url)]
+        [RegularExpression(Constants.GenericStringRegex)]
+        [JsonProperty(PropertyName = "CalendarServerUrl", Required = Required.Always)]
+        public string CalendarServerUrl { get; set; }
+
+        [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
+        [OpenApiProperty(Description = "DateCreated")]
+        [MaxLength(2048)]
+        [DataType(DataType.Date)]
+        [JsonProperty(PropertyName = "DateCreated")]
+        public DateTime DateCreated { get; set; } = DateTime.UtcNow;
+    }
+
+    public class FindTimestampModel
+    {
+        [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
+        [OpenApiProperty(Description = "DateCreatedStart")]
+        [MaxLength(2048)]
+        [DataType(DataType.Date)]
+        [JsonProperty(PropertyName = "DateCreatedStart", Required = Required.Always)]
+        public DateTime DateCreatedStart { get; set; }
+
+        [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
+        [OpenApiProperty(Description = "DateCreatedEnd")]
+        [MaxLength(2048)]
+        [DataType(DataType.Date)]
+        [JsonProperty(PropertyName = "DateCreatedEnd", Required = Required.Always)]
+        public DateTime DateCreatedEnd { get; set; }
+    }
+}

--- a/TrueVote.Api/Models/TimestampModel.cs
+++ b/TrueVote.Api/Models/TimestampModel.cs
@@ -4,7 +4,6 @@ using Microsoft.EntityFrameworkCore.Metadata.Internal;
 using Newtonsoft.Json;
 using System;
 using System.ComponentModel.DataAnnotations;
-using System.ComponentModel.DataAnnotations.Schema;
 using System.Diagnostics.CodeAnalysis;
 
 namespace TrueVote.Api.Models

--- a/TrueVote.Api/Models/UserModel.cs
+++ b/TrueVote.Api/Models/UserModel.cs
@@ -98,17 +98,11 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "Email", Required = Required.Always)]
         public string Email { get; set; }
 
-        private DateTime? _DateCreated = null;
-
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
         [MaxLength(2048)]
         [DataType(DataType.Date)]
         [JsonProperty(PropertyName = "DateCreated")]
-        public DateTime DateCreated
-        {
-            get => _DateCreated ?? DateTime.UtcNow;
-            set => _DateCreated = value;
-        }
+        public DateTime DateCreated { get; set; } = DateTime.UtcNow;
     }
 }

--- a/TrueVote.Api/Models/UserModel.cs
+++ b/TrueVote.Api/Models/UserModel.cs
@@ -98,11 +98,17 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "Email", Required = Required.Always)]
         public string Email { get; set; }
 
+        private DateTime _DateCreated;
+
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
         [MaxLength(2048)]
         [DataType(DataType.Date)]
         [JsonProperty(PropertyName = "DateCreated")]
-        public DateTime DateCreated { get; set; } = DateTime.UtcNow;
+        public DateTime DateCreated
+        {
+            get => _DateCreated = _DateCreated == DateTime.MinValue ? DateTime.UtcNow : _DateCreated;
+            set => _DateCreated = value;
+        }
     }
 }

--- a/TrueVote.Api/Models/UserModel.cs
+++ b/TrueVote.Api/Models/UserModel.cs
@@ -98,7 +98,7 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "Email", Required = Required.Always)]
         public string Email { get; set; }
 
-        private DateTime _DateCreated;
+        private DateTime? _DateCreated = null;
 
         [OpenApiSchemaVisibility(OpenApiVisibilityType.Important)]
         [OpenApiProperty(Description = "DateCreated")]
@@ -107,7 +107,7 @@ namespace TrueVote.Api.Models
         [JsonProperty(PropertyName = "DateCreated")]
         public DateTime DateCreated
         {
-            get => _DateCreated = _DateCreated == DateTime.MinValue ? DateTime.UtcNow : _DateCreated;
+            get => _DateCreated ?? DateTime.UtcNow;
             set => _DateCreated = value;
         }
     }

--- a/TrueVote.Api/Services/Health.cs
+++ b/TrueVote.Api/Services/Health.cs
@@ -14,7 +14,7 @@ namespace TrueVote.Api.Services
         [FunctionName("HealthTimer")]
         public void Run([TimerTrigger("*/5 * * * *")] TimerInfo timerInfo)
         {
-            LogInformation($"HealthTimer trigger function {timerInfo.Schedule} executed at: {DateTime.Now.ToUniversalTime().ToString("dddd, MMM dd, yyyy HH:mm:ss")}");
+            LogInformation($"HealthTimer trigger function {timerInfo.Schedule} executed at: {DateTime.Now.ToUniversalTime():dddd, MMM dd, yyyy HH:mm:ss}");
         }
     }
 }

--- a/TrueVote.Api/Services/Query.cs
+++ b/TrueVote.Api/Services/Query.cs
@@ -16,12 +16,10 @@ namespace TrueVote.Api.Services
     public class Query : LoggerHelper
     {
         private readonly ITrueVoteDbContext _trueVoteDbContext;
-        private readonly TelegramBot _telegramBot;
 
         public Query(ILogger log, ITrueVoteDbContext trueVoteDbContext, TelegramBot telegramBot) : base(log, telegramBot)
         {
             _trueVoteDbContext = trueVoteDbContext;
-            _telegramBot = telegramBot;
         }
 
         public async Task<IReadOnlyList<CandidateModel>> GetCandidate()

--- a/TrueVote.Api/Services/Race.cs
+++ b/TrueVote.Api/Services/Race.cs
@@ -111,7 +111,7 @@ namespace TrueVote.Api.Services
 
             LogInformation($"Request Data: {addCandidatesModel}");
 
-            // Check if the race exists. If so, return it detatched from EF
+            // Check if the race exists. If so, return it detached from EF
             var race = await _trueVoteDbContext.Races.Where(r => r.RaceId == addCandidatesModel.RaceId).AsNoTracking().OrderByDescending(r => r.DateCreated).FirstOrDefaultAsync();
             if (race == null)
             {

--- a/TrueVote.Api/Services/TelegramBot.cs
+++ b/TrueVote.Api/Services/TelegramBot.cs
@@ -45,6 +45,7 @@ namespace TrueVote.Api.Services
             // List of BotCommands
             var commands = new List<BotCommand>() {
                 new BotCommand { Command = "help", Description = "📖 View summary of what the bot can do" },
+                new BotCommand { Command = "ballots", Description = "🖥 View the count of total number of ballots" },
                 new BotCommand { Command = "elections", Description = "🖥 View the count of total number of elections" },
                 new BotCommand { Command = "status", Description = "🖥 View the API status" },
                 new BotCommand { Command = "version", Description = "🤖 View the API version" }
@@ -163,6 +164,13 @@ namespace TrueVote.Api.Services
                         break;
                     }
 
+                case "/ballots":
+                    {
+                        var ret = await GetBallotsCountAsync();
+                        messageResponse = $"Total Ballots: {ret}";
+                        break;
+                    }
+
                 case "/status":
                     {
                         var ret = await GetStatusAsync();
@@ -206,7 +214,7 @@ namespace TrueVote.Api.Services
             return Task.CompletedTask;
         }
 
-        private async Task<Message> SendMessageAsync(ChatId chatId, string text, CancellationToken cancellationToken)
+        private static async Task<Message> SendMessageAsync(ChatId chatId, string text, CancellationToken cancellationToken)
         {
             try
             {
@@ -232,7 +240,7 @@ namespace TrueVote.Api.Services
             }
         }
 
-        private async Task<string> GetElectionsCountAsync()
+        private static async Task<string> GetElectionsCountAsync()
         {
             try
             {
@@ -253,7 +261,28 @@ namespace TrueVote.Api.Services
             }
         }
 
-        private async Task<string> GetStatusAsync()
+        private static async Task<string> GetBallotsCountAsync()
+        {
+            try
+            {
+                var client = new HttpClient(httpClientHandler);
+
+                var countBallotsObj = new CountBallotModel { DateCreatedStart = new DateTime(2023, 01, 01), DateCreatedEnd = new DateTime(2033, 12, 31) };
+                var json = JsonConvert.SerializeObject(countBallotsObj);
+                var httpRequestMessage = new HttpRequestMessage { RequestUri = new Uri($"{BaseApiUrl}/ballot/count"), Method = HttpMethod.Get, Content = new StringContent(json.ToString()) };
+                var ret = await client.SendAsync(httpRequestMessage);
+
+                var retCount = await ret.Content.ReadAsAsync<int>();
+
+                return retCount.ToString();
+            }
+            catch (Exception e)
+            {
+                return $"Error: {e.Message}";
+            }
+        }
+
+        private static async Task<string> GetStatusAsync()
         {
             try
             {
@@ -275,7 +304,7 @@ namespace TrueVote.Api.Services
         }
 
         // TODO Need to really get version from assembly info. Better than Git tag
-        private async Task<string> GetVersionAsync()
+        private static async Task<string> GetVersionAsync()
         {
             try
             {

--- a/TrueVote.Api/Services/TelegramBot.cs
+++ b/TrueVote.Api/Services/TelegramBot.cs
@@ -37,7 +37,7 @@ namespace TrueVote.Api.Services
 
         private async void Init()
         {
-            if (botClient != null) // In case the function is called again, if it's iniatialized, don't do it again
+            if (botClient != null) // In case the function is called again, if it's initialized, don't do it again
                 return;
 
             using var cts = new CancellationTokenSource();
@@ -54,21 +54,21 @@ namespace TrueVote.Api.Services
             var botKey = Environment.GetEnvironmentVariable("TelegramBotKey");
             if (string.IsNullOrEmpty(botKey))
             {
-                Console.WriteLine("Error retreiving Telegram BotKey");
+                Console.WriteLine("Error retrieving Telegram BotKey");
                 return;
             }
 
             TelegramRuntimeChannel = Environment.GetEnvironmentVariable("TelegramRuntimeChannel");
             if (string.IsNullOrEmpty(TelegramRuntimeChannel))
             {
-                Console.WriteLine("Error retreiving TelegramRuntimeChannel");
+                Console.WriteLine("Error retrieving TelegramRuntimeChannel");
                 return;
             }
 
             BaseApiUrl = Environment.GetEnvironmentVariable("BaseApiUrl");
             if (string.IsNullOrEmpty(BaseApiUrl))
             {
-                Console.WriteLine("Error retreiving BaseApiUrl");
+                Console.WriteLine("Error retrieving BaseApiUrl");
                 return;
             }
 

--- a/TrueVote.Api/Services/TelegramBot.cs
+++ b/TrueVote.Api/Services/TelegramBot.cs
@@ -13,6 +13,7 @@ using Newtonsoft.Json;
 using TrueVote.Api.Models;
 using Microsoft.Azure.Functions.Extensions.DependencyInjection;
 using TrueVote.Api.Services;
+using Telegram.Bot.Polling;
 
 // TODO Localize this service, since it returns English messages to Telegram
 // See local.settings.json for local settings and Azure Portal for production settings

--- a/TrueVote.Api/Services/Timestamp.cs
+++ b/TrueVote.Api/Services/Timestamp.cs
@@ -1,0 +1,74 @@
+using System;
+using System.IO;
+using System.Linq;
+using System.Net;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Azure.WebJobs;
+using Microsoft.Azure.WebJobs.Extensions.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Microsoft.OpenApi.Models;
+using Newtonsoft.Json;
+using TrueVote.Api.Helpers;
+using TrueVote.Api.Interfaces;
+using TrueVote.Api.Models;
+
+namespace TrueVote.Api.Services
+{
+    public class Timestamp : LoggerHelper
+    {
+        private readonly ITrueVoteDbContext _trueVoteDbContext;
+        private readonly TelegramBot _telegramBot;
+
+        public Timestamp(ILogger log, ITrueVoteDbContext trueVoteDbContext, TelegramBot telegramBot) : base(log, telegramBot)
+        {
+            _trueVoteDbContext = trueVoteDbContext;
+            _telegramBot = telegramBot;
+        }
+
+        [FunctionName(nameof(TimestampFind))]
+        [ProducesResponseType(StatusCodes.Status200OK)]
+        [ProducesResponseType(StatusCodes.Status404NotFound)]
+        [OpenApiOperation(operationId: "TimestampFind", tags: new[] { "Timestamp" })]
+        [OpenApiSecurity("oidc_auth", SecuritySchemeType.OpenIdConnect, OpenIdConnectUrl = "https://login.microsoftonline.com/{tenant_id}/v2.0/.well-known/openid-configuration", OpenIdConnectScopes = "openid,profile")]
+        [OpenApiRequestBody(contentType: "application/json", bodyType: typeof(FindTimestampModel), Description = "Fields to search for Timestamps", Example = typeof(FindTimestampModel))]
+        [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(CandidateModelList), Description = "Returns collection of Candidates")]
+        [OpenApiResponseWithBody(statusCode: HttpStatusCode.Forbidden, contentType: "application/json", bodyType: typeof(SecureString), Description = "Forbidden")]
+        [OpenApiResponseWithBody(statusCode: HttpStatusCode.Unauthorized, contentType: "application/json", bodyType: typeof(SecureString), Description = "Unauthorized")]
+        [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotFound, contentType: "application/json", bodyType: typeof(SecureString), Description = "Not Found")]
+        [OpenApiResponseWithBody(statusCode: HttpStatusCode.NotAcceptable, contentType: "application/json", bodyType: typeof(SecureString), Description = "Not Acceptable")]
+        [OpenApiResponseWithBody(statusCode: HttpStatusCode.TooManyRequests, contentType: "application/json", bodyType: typeof(SecureString), Description = "Too Many Requests")]
+        public async Task<IActionResult> TimestampFind(
+            [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "timestamp/find")] HttpRequest req)
+        {
+            LogDebug("HTTP trigger - TimestampFind:Begin");
+
+            FindTimestampModel findTimestamp;
+            try
+            {
+                var requestBody = await new StreamReader(req.Body).ReadToEndAsync();
+                findTimestamp = JsonConvert.DeserializeObject<FindTimestampModel>(requestBody);
+            }
+            catch (Exception e)
+            {
+                LogError("findTimestamp: invalid format");
+                LogDebug("HTTP trigger - TimestampFind:End");
+
+                return new BadRequestObjectResult(e.Message);
+            }
+
+            LogInformation($"Request Data: {findTimestamp}");
+
+            var items = await _trueVoteDbContext.Timestamps
+                .Where(c => c.DateCreated >= findTimestamp.DateCreatedStart && c.DateCreated <= findTimestamp.DateCreatedEnd)
+                .OrderByDescending(c => c.DateCreated).ToListAsync();
+
+            LogDebug("HTTP trigger - TimestampFind:End");
+
+            return items.Count == 0 ? new NotFoundResult() : new OkObjectResult(items);
+        }
+    }
+}

--- a/TrueVote.Api/Services/User.cs
+++ b/TrueVote.Api/Services/User.cs
@@ -110,7 +110,7 @@ namespace TrueVote.Api.Services
 
             LogInformation($"Request Data: {findUser}");
 
-            // TODO Simplify this query by putting the and conditions in an extension methods to build the where clause more idomatically. It should iterate
+            // TODO Simplify this query by putting the and conditions in an extension methods to build the where clause more idiomatically. It should iterate
             // through all the properties in FindUserModel and build the .Where clause dynamically.
             var items = await _trueVoteDbContext.Users
                 .Where(u =>

--- a/TrueVote.Api/Services/Validator.cs
+++ b/TrueVote.Api/Services/Validator.cs
@@ -67,14 +67,6 @@ namespace TrueVote.Api.Services
             return timestamp;
         }
 
-        [FunctionName("Validator")]
-        public async Task Run([TimerTrigger("*/1 * * * *")] TimerInfo timerInfo)
-        {
-            LogInformation($"ValidatorTimer trigger function {timerInfo.Schedule} executed at: {DateTime.Now.ToUniversalTime():dddd, MMM dd, yyyy HH:mm:ss}");
-
-            await HashBallotsAsync();
-        }
-
         private async Task StoreTimestampAsync(TimestampModel timestamp)
         {
             try
@@ -88,6 +80,14 @@ namespace TrueVote.Api.Services
                 LogError($"Exception storing timestamp: {ex.Message}");
                 throw;
             }
+        }
+
+        [FunctionName("Validator")]
+        public async Task Run([TimerTrigger("*/1 * * * *")] TimerInfo timerInfo)
+        {
+            LogInformation($"ValidatorTimer trigger function {timerInfo.Schedule} executed at: {DateTime.Now.ToUniversalTime():dddd, MMM dd, yyyy HH:mm:ss}");
+
+            await HashBallotsAsync();
         }
     }
 }

--- a/TrueVote.Api/Services/Validator.cs
+++ b/TrueVote.Api/Services/Validator.cs
@@ -1,4 +1,3 @@
-using Microsoft.Azure.WebJobs;
 using Microsoft.Extensions.Logging;
 using System;
 using TrueVote.Api.Helpers;
@@ -80,14 +79,6 @@ namespace TrueVote.Api.Services
                 LogError($"Exception storing timestamp: {ex.Message}");
                 throw;
             }
-        }
-
-        [FunctionName("Validator")]
-        public async Task Run([TimerTrigger("*/1 * * * *")] TimerInfo timerInfo)
-        {
-            LogInformation($"ValidatorTimer trigger function {timerInfo.Schedule} executed at: {DateTime.Now.ToUniversalTime():dddd, MMM dd, yyyy HH:mm:ss}");
-
-            await HashBallotsAsync();
         }
     }
 }

--- a/TrueVote.Api/Services/Validator.cs
+++ b/TrueVote.Api/Services/Validator.cs
@@ -20,11 +20,13 @@ namespace TrueVote.Api.Services
     {
         private readonly ITrueVoteDbContext _trueVoteDbContext;
         private readonly TelegramBot _telegramBot;
+        private readonly IOpenTimestampsClient _openTimestampsClient;
 
-        public Validator(ILogger log, ITrueVoteDbContext trueVoteDbContext, TelegramBot telegramBot) : base(log, telegramBot)
+        public Validator(ILogger log, ITrueVoteDbContext trueVoteDbContext, TelegramBot telegramBot, IOpenTimestampsClient openTimestampsClient) : base(log, telegramBot)
         {
             _trueVoteDbContext = trueVoteDbContext;
             _telegramBot = telegramBot;
+            _openTimestampsClient = openTimestampsClient;
         }
 
         public Timestamp HashBallots()
@@ -39,8 +41,7 @@ namespace TrueVote.Api.Services
             var merkleRootHash = MerkleTree.GetHash(merkleRoot);
 
             // Timestamp the Merkle root
-            var otsClient = new OpenTimestampsClient(new Uri("https://a.pool.opentimestamps.org"));
-            var result = otsClient.Stamp(merkleRootHash).Result;
+            var result = _openTimestampsClient.Stamp(merkleRootHash).Result;
 
             // Store the timestamp record in a model
             var timestamp = new Timestamp

--- a/TrueVote.Api/Services/Validator.cs
+++ b/TrueVote.Api/Services/Validator.cs
@@ -1,0 +1,65 @@
+using Microsoft.Azure.WebJobs;
+using Microsoft.Extensions.Logging;
+using System;
+using TrueVote.Api.Helpers;
+using System.Linq;
+using TrueVote.Api.Interfaces;
+
+namespace TrueVote.Api.Services
+{
+    public class Timestamp
+    {
+        public byte[] MerkleRoot { get; set; }
+        public byte[] MerkleRootHash { get; set; }
+        public string TimestampHash { get; set; }
+        public DateTime TimestampAt { get; set; }
+    }
+
+    public class Validator : LoggerHelper
+    {
+        private readonly ITrueVoteDbContext _trueVoteDbContext;
+        private readonly TelegramBot _telegramBot;
+
+        public Validator(ILogger log, ITrueVoteDbContext trueVoteDbContext, TelegramBot telegramBot) : base(log, telegramBot)
+        {
+            _trueVoteDbContext = trueVoteDbContext;
+            _telegramBot = telegramBot;
+        }
+
+        [FunctionName("Validator")]
+        public void Run([TimerTrigger("*/1 * * * *")] TimerInfo timerInfo)
+        {
+            LogInformation($"ValidatorTimer trigger function {timerInfo.Schedule} executed at: {DateTime.Now.ToUniversalTime().ToString("dddd, MMM dd, yyyy HH:mm:ss")}");
+
+            // Get all the ballots
+            var items = _trueVoteDbContext.Ballots.OrderByDescending(e => e.DateCreated).ToList();
+
+            // Generate Merkle root from data list
+            var merkleRoot = MerkleTree.CalculateMerkleRoot(items);
+
+            // Hash the Merkle root
+            var merkleRootHash = MerkleTree.GetHash(merkleRoot);
+
+            // Timestamp the Merkle root
+            var otsClient = new OpenTimestampsClient(new Uri("https://a.pool.opentimestamps.org"));
+            var result = otsClient.Stamp(merkleRootHash).Result;
+
+            // Store the timestamp record in SQL
+            var timestamp = new Timestamp
+            {
+                MerkleRoot = merkleRoot,
+                MerkleRootHash = merkleRootHash,
+                TimestampHash = result.ToString(),
+                TimestampAt = DateTime.UtcNow
+            };
+
+            // Store the timestamp in Database
+            StoreTimestamp(timestamp);
+        }
+
+        private void StoreTimestamp(Timestamp timestamp)
+        {
+            Console.WriteLine(timestamp.ToString());
+        }
+    }
+}

--- a/TrueVote.Api/Startup.cs
+++ b/TrueVote.Api/Startup.cs
@@ -22,6 +22,7 @@ using System.Threading.Tasks;
 using TrueVote.Api.Interfaces;
 using TrueVote.Api.Models;
 using TrueVote.Api.Services;
+using TrueVote.Api.Helpers;
 
 [assembly: FunctionsStartup(typeof(TrueVote.Api.Startup))]
 namespace TrueVote.Api
@@ -166,6 +167,9 @@ namespace TrueVote.Api
 
             builder.Services.TryAddSingleton<INamingConventions, TrueVoteNamingConventions>();
             builder.AddGraphQLFunction().AddQueryType<Query>();
+
+            // Additional classes for dependency injection
+            builder.Services.TryAddScoped<IOpenTimestampsClient, OpenTimestampsClient>();
 
             ConfigureServices(builder.Services).BuildServiceProvider(true);
         }

--- a/TrueVote.Api/Startup.cs
+++ b/TrueVote.Api/Startup.cs
@@ -91,6 +91,7 @@ namespace TrueVote.Api
         public virtual DbSet<RaceModel> Races { get; set; }
         public virtual DbSet<CandidateModel> Candidates { get; set; }
         public virtual DbSet<BallotModel> Ballots { get; set; }
+        public virtual DbSet<TimestampModel> Timestamps { get; set; }
 
         public virtual async Task<bool> EnsureCreatedAsync()
         {
@@ -150,6 +151,10 @@ namespace TrueVote.Api
             modelBuilder.HasDefaultContainer("Candidates");
             modelBuilder.Entity<CandidateModel>().ToContainer("Candidates");
             modelBuilder.Entity<CandidateModel>().HasNoDiscriminator();
+
+            modelBuilder.HasDefaultContainer("Timestamps");
+            modelBuilder.Entity<TimestampModel>().ToContainer("Timestamps");
+            modelBuilder.Entity<TimestampModel>().HasNoDiscriminator();
         }
     }
 
@@ -169,7 +174,12 @@ namespace TrueVote.Api
             builder.AddGraphQLFunction().AddQueryType<Query>();
 
             // Additional classes for dependency injection
-            builder.Services.TryAddScoped<IOpenTimestampsClient, OpenTimestampsClient>();
+            builder.Services.TryAddSingleton(new Uri("https://a.pool.opentimestamps.org")); // TODO Need to pull the Timestamp URL from Config. Also, TrueVote needs to stand up its own Timestamp servers.
+            builder.Services.AddHttpClient<IOpenTimestampsClient, OpenTimestampsClient>().ConfigureHttpClient((provider, client) => 
+            {
+                var uri = provider.GetRequiredService<Uri>();
+                client.BaseAddress = uri;
+            });
 
             ConfigureServices(builder.Services).BuildServiceProvider(true);
         }

--- a/TrueVote.Api/Startup.cs
+++ b/TrueVote.Api/Startup.cs
@@ -184,7 +184,7 @@ namespace TrueVote.Api
             ConfigureServices(builder.Services).BuildServiceProvider(true);
         }
 
-        private IServiceCollection ConfigureServices(IServiceCollection services)
+        private static IServiceCollection ConfigureServices(IServiceCollection services)
         {
             services.AddLogging();
             services.AddSingleton(typeof(ILogger), typeof(Logger<Startup>));

--- a/TrueVote.Api/TrueVote.Api.csproj
+++ b/TrueVote.Api/TrueVote.Api.csproj
@@ -36,6 +36,7 @@
     <PackageReference Include="System.IO.Abstractions" Version="19.2.22" />
     <PackageReference Include="Telegram.Bot" Version="19.0.0" />
     <PackageReference Include="Telegram.Bot.Extensions.Polling" Version="1.0.2" />
+    <PackageReference Include="Utf8Json" Version="1.3.7" />
   </ItemGroup>
   <ItemGroup>
     <None Update="local-certificate.pfx">


### PR DESCRIPTION
Partial implementation of Ballot Hashing. Still TODO:

AD-54 - Add new model to store hashes for each Ballot
AD-55 - Stand up TrueVote hosted Opentimestamp Calendar services. Currently has a hard-wired public calendar until this is done.
AD-58 - Call Validator() service periodically hash the hashes and actually call Opentimestamps