### PR TITLE
Added style cop and analyzer. Enabled errors instead of warnings.

### DIFF
--- a/TrueVote.Api/Helpers/JwtAuth.cs
+++ b/TrueVote.Api/Helpers/JwtAuth.cs
@@ -1,8 +1,8 @@
-using Microsoft.IdentityModel.Tokens;
-using System.Security.Claims;
-using System.IdentityModel.Tokens.Jwt;
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Primitives;
+using Microsoft.IdentityModel.Tokens;
+using System.Diagnostics.CodeAnalysis;
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
 
 /* 
  * This class shouldn't need to exist. The preferred method is to use the [Authorize] attribute on endpoints to

--- a/TrueVote.Api/TrueVote.Api.csproj
+++ b/TrueVote.Api/TrueVote.Api.csproj
@@ -14,10 +14,10 @@
     <ApplicationIcon>dist\favicon.ico</ApplicationIcon>
     <RepositoryUrl>https://github.com/TrueVote/TrueVote.Api</RepositoryUrl>
     <RepositoryType>git</RepositoryType>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateRuntimeConfigurationFiles>true</GenerateRuntimeConfigurationFiles>
   </PropertyGroup>
   <ItemGroup>
-    <Content Remove="local.settings.json" />
     <Content Remove="version.json" />
   </ItemGroup>
   <ItemGroup>
@@ -38,6 +38,14 @@
     </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.20.0-Preview.1" />
     <PackageReference Include="NSwag.AspNetCore" Version="14.0.7" />
+    <PackageReference Include="SonarAnalyzer.CSharp" Version="9.23.0.88079">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="StyleCop.Analyzers" Version="1.1.118">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
     <PackageReference Include="Microsoft.CodeAnalysis" Version="4.9.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.3" />


### PR DESCRIPTION
Added analyzers including StyleCop.
Turned all warnings to errors.
Don't know the coding guidelines here, so didn't suppress anything.

Example of error output after analyzers and style rules were implemented:
![image](https://github.com/TrueVote/TrueVote.Api/assets/30846796/56e496d7-f2af-4005-b9d2-c0e763b473e9)


Resolves #24 