### PR TITLE
AD-121 Adds ElectionAccessCode requirement for ballot submission

### DIFF
--- a/TrueVote.Api.Tests/HelperTests/CustomValidatorTest.cs
+++ b/TrueVote.Api.Tests/HelperTests/CustomValidatorTest.cs
@@ -163,7 +163,7 @@ namespace TrueVote.Api.Tests.HelperTests
         [Fact]
         public void BallotIntegrityCheckerHandlesUnfoundElection()
         {
-            var baseBallotObj = new SubmitBallotModel { Election = MoqData.MockBallotData[1].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[1].Election };
             baseBallotObj.Election.ElectionId = "willnotfind";
             var validationContext = new ValidationContext(baseBallotObj);
             validationContext.Items["IsBallot"] = true;
@@ -180,7 +180,7 @@ namespace TrueVote.Api.Tests.HelperTests
         [Fact]
         public void BallotIntegrityCheckerHandlesMissingDBContext()
         {
-            var baseBallotObj = new SubmitBallotModel { Election = MoqData.MockBallotData[1].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[1].Election };
             var validationContext = new ValidationContext(baseBallotObj);
             validationContext.Items["IsBallot"] = true;
             // validationContext.Items["DBContext"] = _trueVoteDbContext;
@@ -196,7 +196,7 @@ namespace TrueVote.Api.Tests.HelperTests
         [Fact]
         public void BallotIntegrityCheckerHandlesSubmissionBeforeElectionStart()
         {
-            var baseBallotObj = new SubmitBallotModel { Election = MoqData.MockBallotData[4].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[4].Election };
 
             var validationContext = new ValidationContext(baseBallotObj);
             validationContext.Items["IsBallot"] = true;
@@ -213,7 +213,7 @@ namespace TrueVote.Api.Tests.HelperTests
         [Fact]
         public void BallotIntegrityCheckerHandlesSubmissionAfterElectionEnd()
         {
-            var baseBallotObj = new SubmitBallotModel { Election = MoqData.MockBallotData[3].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[3].Election };
 
             var validationContext = new ValidationContext(baseBallotObj);
             validationContext.Items["IsBallot"] = true;
@@ -230,7 +230,7 @@ namespace TrueVote.Api.Tests.HelperTests
         [Fact]
         public void BallotIntegrityCheckerHandlesSelectionDifferences()
         {
-            var baseBallotObj = new SubmitBallotModel { Election = MoqData.MockBallotData[0].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[0].Election };
             baseBallotObj.Election.Races[0].Candidates[0].Selected = true;
             baseBallotObj.Election.Races[0].Candidates[1].Selected = true;
             var validationContext = new ValidationContext(baseBallotObj);

--- a/TrueVote.Api.Tests/HelperTests/ModelDiffValidatorTest.cs
+++ b/TrueVote.Api.Tests/HelperTests/ModelDiffValidatorTest.cs
@@ -73,7 +73,7 @@ namespace TrueVote.Api.Tests.HelperTests
         [Fact]
         public void ModelDiffHandlesNullModels()
         {
-            var modelA = new SubmitBallotModel { Election = null };
+            var modelA = new SubmitBallotModel { AccessCode = null, Election = null };
             var modelB = (SubmitBallotModel) null;
 
             var diff1 = modelA.ModelDiff(modelB);

--- a/TrueVote.Api.Tests/HelperTests/RecursiveValidatorTest.cs
+++ b/TrueVote.Api.Tests/HelperTests/RecursiveValidatorTest.cs
@@ -24,7 +24,7 @@ namespace TrueVote.Api.Tests.HelperTests
         public void ValidatesModelWithNestedModelProperties()
         {
             var validationResults = new List<ValidationResult>();
-            var baseBallotObj = new SubmitBallotModel { Election = MoqData.MockBallotData[1].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[1].Election };
             var validationContext = new ValidationContext(baseBallotObj);
             validationContext.Items["IsBallot"] = true;
             validationContext.Items["DBContext"] = _trueVoteDbContext;
@@ -39,7 +39,7 @@ namespace TrueVote.Api.Tests.HelperTests
         public void HandlesModelWithNullNestedModelProperties()
         {
             var validationResults = new List<ValidationResult>();
-            var baseBallotObj = new SubmitBallotModel { Election = MoqData.MockBallotData[1].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[1].Election };
             baseBallotObj.Election.Races = null;
             var validationContext = new ValidationContext(baseBallotObj);
             validationContext.Items["IsBallot"] = true;
@@ -99,7 +99,7 @@ namespace TrueVote.Api.Tests.HelperTests
         public void ValidatorHandlesNullModel()
         {
             var validationResults = new List<ValidationResult>();
-            var baseBallotObj = new SubmitBallotModel { Election = MoqData.MockBallotData[1].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[1].Election };
             var validationContext = new ValidationContext(baseBallotObj);
             var validModel = recursiveValidator.TryValidateObjectRecursive(null, validationContext, validationResults);
             Assert.True(validModel);
@@ -210,7 +210,7 @@ namespace TrueVote.Api.Tests.HelperTests
         [Fact]
         public void BallotIntegrityCheckerHandlesUnfoundElection()
         {
-            var baseBallotObj = new SubmitBallotModel { Election = MoqData.MockBallotData[1].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[1].Election };
             baseBallotObj.Election.ElectionId = "willnotfind";
             var validationContext = new ValidationContext(baseBallotObj);
             validationContext.Items["IsBallot"] = true;
@@ -227,7 +227,7 @@ namespace TrueVote.Api.Tests.HelperTests
         [Fact]
         public void BallotIntegrityCheckerHandlesMissingDBContext()
         {
-            var baseBallotObj = new SubmitBallotModel { Election = MoqData.MockBallotData[1].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[1].Election };
             var validationContext = new ValidationContext(baseBallotObj);
             validationContext.Items["IsBallot"] = true;
             // validationContext.Items["DBContext"] = _trueVoteDbContext;
@@ -243,7 +243,7 @@ namespace TrueVote.Api.Tests.HelperTests
         [Fact]
         public void BallotIntegrityCheckerHandlesSubmissionBeforeElectionStart()
         {
-            var baseBallotObj = new SubmitBallotModel { Election = MoqData.MockBallotData[4].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[4].Election };
 
             var validationContext = new ValidationContext(baseBallotObj);
             validationContext.Items["IsBallot"] = true;
@@ -260,7 +260,7 @@ namespace TrueVote.Api.Tests.HelperTests
         [Fact]
         public void BallotIntegrityCheckerHandlesSubmissionAfterElectionEnd()
         {
-            var baseBallotObj = new SubmitBallotModel { Election = MoqData.MockBallotData[3].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[3].Election };
 
             var validationContext = new ValidationContext(baseBallotObj);
             validationContext.Items["IsBallot"] = true;
@@ -277,7 +277,7 @@ namespace TrueVote.Api.Tests.HelperTests
         [Fact]
         public void BallotIntegrityCheckerHandlesSelectionDifferences()
         {
-            var baseBallotObj = new SubmitBallotModel { Election = MoqData.MockBallotData[0].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[0].Election };
             baseBallotObj.Election.Races[0].Candidates[0].Selected = true;
             baseBallotObj.Election.Races[0].Candidates[1].Selected = true;
             var validationContext = new ValidationContext(baseBallotObj);

--- a/TrueVote.Api.Tests/MoqData.cs
+++ b/TrueVote.Api.Tests/MoqData.cs
@@ -93,6 +93,12 @@ namespace TrueVote.Api.Tests
             new AccessCodeModel { DateCreated = createDate, RequestId = "125", ElectionId = "blah", AccessCode = "accesscode3", RequestDescription = "Mock Election Access Code Harness 3", RequestedByUserId = MockUserData[0].UserId }
         };
 
+        public static List<UsedAccessCodeModel> MockUsedAccessCodeData => new()
+        {
+            new UsedAccessCodeModel { AccessCode = "accesscode1" },
+            new UsedAccessCodeModel { AccessCode = "accesscode2" },
+        };
+
         public static BallotList MockBallotList => new()
         {
             Ballots = MockBallotData,
@@ -111,6 +117,7 @@ namespace TrueVote.Api.Tests
         public readonly Mock<MoqTrueVoteDbContext> mockBallotHashContext;
         public readonly Mock<MoqTrueVoteDbContext> mockFeedbacksContext;
         public readonly Mock<MoqTrueVoteDbContext> mockElectionAccessCodeContext;
+        public readonly Mock<MoqTrueVoteDbContext> mockUsedAccessCodeContext;
 
         public Mock<DbSet<UserModel>> MockUserSet { get; private set; }
         public Mock<DbSet<RaceModel>> MockRaceSet { get; private set; }
@@ -121,6 +128,7 @@ namespace TrueVote.Api.Tests
         public Mock<DbSet<BallotHashModel>> MockBallotHashSet { get; private set; }
         public Mock<DbSet<FeedbackModel>> MockFeedbackSet { get; private set; }
         public Mock<DbSet<AccessCodeModel>> MockElectionAccessCodeSet { get; private set; }
+        public Mock<DbSet<UsedAccessCodeModel>> MockUsedAccessCodeSet { get; private set; }
 
         // https://docs.microsoft.com/en-us/ef/ef6/fundamentals/testing/mocking?redirectedfrom=MSDN
         // https://github.com/romantitov/MockQueryable
@@ -135,6 +143,7 @@ namespace TrueVote.Api.Tests
             MockRaceSet = MoqData.MockRaceData.AsQueryable().BuildMockDbSet();
             MockFeedbackSet = MoqData.MockFeedbackData.AsQueryable().BuildMockDbSet();
             MockElectionAccessCodeSet = MoqData.MockElectionAccessCodeData.AsQueryable().BuildMockDbSet();
+            MockUsedAccessCodeSet = MoqData.MockUsedAccessCodeData.AsQueryable().BuildMockDbSet();
 
             mockUserContext = new Mock<MoqTrueVoteDbContext>();
             mockUserContext.Setup(m => m.Feedbacks).Returns(MockFeedbackSet.Object);
@@ -146,6 +155,7 @@ namespace TrueVote.Api.Tests
             mockElectionContext.Setup(m => m.Races).Returns(MockRaceSet.Object);
             mockElectionContext.Setup(m => m.Users).Returns(MockUserSet.Object);
             mockElectionContext.Setup(m => m.ElectionAccessCodes).Returns(MockElectionAccessCodeSet.Object);
+            mockElectionContext.Setup(m => m.UsedAccessCodes).Returns(MockUsedAccessCodeSet.Object);
             mockElectionContext.Setup(m => m.EnsureCreatedAsync()).Returns(Task.FromResult(true));
 
             mockTimestampContext = new Mock<MoqTrueVoteDbContext>();
@@ -182,6 +192,10 @@ namespace TrueVote.Api.Tests
             mockElectionAccessCodeContext.Setup(m => m.ElectionAccessCodes).Returns(MockElectionAccessCodeSet.Object);
             mockElectionAccessCodeContext.Setup(m => m.EnsureCreatedAsync()).Returns(Task.FromResult(true));
 
+            mockUsedAccessCodeContext = new Mock<MoqTrueVoteDbContext>();
+            mockUsedAccessCodeContext.Setup(m => m.UsedAccessCodes).Returns(MockUsedAccessCodeSet.Object);
+            mockUsedAccessCodeContext.Setup(m => m.EnsureCreatedAsync()).Returns(Task.FromResult(true));
+
             // Leaving commented code. This is for Mocking UTC time. Helpful for test consistency.
             // var mockUtcNowProvider = new Mock<IUtcNowProvider>();
             // mockUtcNowProvider.Setup(p => p.UtcNow).Returns(MoqData.startDate);
@@ -201,6 +215,7 @@ namespace TrueVote.Api.Tests
         public virtual DbSet<BallotHashModel> BallotHashes { get; set; }
         public virtual DbSet<FeedbackModel> Feedbacks { get; set; }
         public virtual DbSet<AccessCodeModel> ElectionAccessCodes { get; set; }
+        public virtual DbSet<UsedAccessCodeModel> UsedAccessCodes { get; set; }
 
         protected MoqDataAccessor _moqDataAccessor;
 
@@ -217,6 +232,7 @@ namespace TrueVote.Api.Tests
             BallotHashes = _moqDataAccessor.MockBallotHashSet.Object;
             Feedbacks = _moqDataAccessor.MockFeedbackSet.Object;
             ElectionAccessCodes = _moqDataAccessor.MockElectionAccessCodeSet.Object;
+            UsedAccessCodes = _moqDataAccessor.MockUsedAccessCodeSet.Object;
         }
 
         public virtual async Task<bool> EnsureCreatedAsync()

--- a/TrueVote.Api.Tests/MoqData.cs
+++ b/TrueVote.Api.Tests/MoqData.cs
@@ -173,6 +173,8 @@ namespace TrueVote.Api.Tests
             mockBallotContext.Setup(m => m.Ballots).Returns(MockBallotSet.Object);
             mockBallotContext.Setup(m => m.BallotHashes).Returns(MockBallotHashSet.Object);
             mockBallotContext.Setup(m => m.Timestamps).Returns(MockTimestampSet.Object);
+            mockBallotContext.Setup(m => m.ElectionAccessCodes).Returns(MockElectionAccessCodeSet.Object);
+            mockBallotContext.Setup(m => m.UsedAccessCodes).Returns(MockUsedAccessCodeSet.Object);
             mockBallotContext.Setup(m => m.EnsureCreatedAsync()).Returns(Task.FromResult(true));
 
             mockCandidateContext = new Mock<MoqTrueVoteDbContext>();

--- a/TrueVote.Api.Tests/MoqData.cs
+++ b/TrueVote.Api.Tests/MoqData.cs
@@ -88,6 +88,7 @@ namespace TrueVote.Api.Tests
 
         public static List<AccessCodeModel> MockElectionAccessCodeData => new()
         {
+            new AccessCodeModel { DateCreated = createDate, RequestId = "122", ElectionId = MockElectionData[0].ElectionId, AccessCode = "accesscode0", RequestDescription = "Mock Election Access Code Harness 0", RequestedByUserId = MockUserData[0].UserId },
             new AccessCodeModel { DateCreated = createDate, RequestId = "123", ElectionId = MockElectionData[0].ElectionId, AccessCode = "accesscode1", RequestDescription = "Mock Election Access Code Harness 1", RequestedByUserId = MockUserData[0].UserId },
             new AccessCodeModel { DateCreated = createDate, RequestId = "124", ElectionId = MockElectionData[0].ElectionId, AccessCode = "accesscode2", RequestDescription = "Mock Election Access Code Harness 2", RequestedByUserId = MockUserData[0].UserId },
             new AccessCodeModel { DateCreated = createDate, RequestId = "125", ElectionId = "blah", AccessCode = "accesscode3", RequestDescription = "Mock Election Access Code Harness 3", RequestedByUserId = MockUserData[0].UserId }

--- a/TrueVote.Api.Tests/ServiceTests/BallotTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/BallotTest.cs
@@ -228,5 +228,52 @@ namespace TrueVote.Api.Tests.ServiceTests
             _logHelper.Verify(LogLevel.Error, Times.Exactly(1));
             _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
         }
+
+        [Fact]
+        public async Task AddsUsedAccessCode()
+        {
+            var usedAccessCode = new UsedAccessCodeModel { AccessCode = "accesscode3" };
+
+            var ret = await _ballotApi.UseAccessCode(usedAccessCode);
+            Assert.NotNull(ret);
+            Assert.Equal(StatusCodes.Status200OK, ((IStatusCodeActionResult) ret).StatusCode);
+
+            _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
+            _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task HandlesWhenCodeAlreadyUsed()
+        {
+            var usedAccessCode = new UsedAccessCodeModel { AccessCode = "accesscode2" };
+
+            var ret = await _ballotApi.UseAccessCode(usedAccessCode);
+            Assert.NotNull(ret);
+            Assert.Equal(StatusCodes.Status409Conflict, ((IStatusCodeActionResult) ret).StatusCode);
+
+            var val = (SecureString) (ret as ConflictObjectResult).Value;
+            Assert.Contains("AccessCode", val.Value.ToString());
+            Assert.Contains("already used", val.Value.ToString());
+
+            _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
+            _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task HandlesWhenCodeDoesNotExist()
+        {
+            var usedAccessCode = new UsedAccessCodeModel { AccessCode = "blah" };
+
+            var ret = await _ballotApi.UseAccessCode(usedAccessCode);
+            Assert.NotNull(ret);
+            Assert.Equal(StatusCodes.Status404NotFound, ((IStatusCodeActionResult) ret).StatusCode);
+
+            var val = (SecureString) (ret as NotFoundObjectResult).Value;
+            Assert.Contains("AccessCode", val.Value.ToString());
+            Assert.Contains("not found", val.Value.ToString());
+
+            _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
+            _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
+        }
     }
 }

--- a/TrueVote.Api.Tests/ServiceTests/BallotTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/BallotTest.cs
@@ -26,7 +26,7 @@ namespace TrueVote.Api.Tests.ServiceTests
         [Fact]
         public async Task SubmitsBallot()
         {
-            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[1].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockElectionAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[1].Election };
 
             var ret = await _ballotApi.SubmitBallot(baseBallotObj);
             Assert.NotNull(ret);
@@ -107,7 +107,7 @@ namespace TrueVote.Api.Tests.ServiceTests
         [Fact]
         public async Task HandlesSubmitBallotHashingError()
         {
-            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[1].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockElectionAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[1].Election };
 
             var mockValidator = new Mock<IBallotValidator>();
             mockValidator.Setup(m => m.HashBallotAsync(It.IsAny<BallotModel>())).Throws(new Exception("Hash Ballot Exception"));
@@ -207,13 +207,15 @@ namespace TrueVote.Api.Tests.ServiceTests
         [Fact]
         public async Task HandlesSubmitBallotDatabaseError()
         {
-            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[1].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockElectionAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[1].Election };
 
             var mockBallotContext = new Mock<MoqTrueVoteDbContext>();
+
             var mockBallotDataQueryable = MoqData.MockBallotData.AsQueryable();
-            var mockBallotHashDataQueryable = MoqData.MockBallotHashData.AsQueryable();
             var MockBallotSet = DbMoqHelper.GetDbSet(mockBallotDataQueryable);
             mockBallotContext.Setup(m => m.Ballots).Returns(MockBallotSet.Object);
+            mockBallotContext.Setup(m => m.ElectionAccessCodes).Returns(_moqDataAccessor.MockElectionAccessCodeSet.Object);
+            mockBallotContext.Setup(m => m.UsedAccessCodes).Returns(_moqDataAccessor.MockUsedAccessCodeSet.Object);
             mockBallotContext.Setup(m => m.SaveChangesAsync()).Throws(new Exception("DB Saving Changes Exception"));
 
             var ballotApi = new Ballot(_logHelper.Object, mockBallotContext.Object, _validatorApi, _mockServiceBus.Object, _mockRecursiveValidator.Object);
@@ -230,47 +232,36 @@ namespace TrueVote.Api.Tests.ServiceTests
         }
 
         [Fact]
-        public async Task AddsUsedAccessCode()
+        public async Task HandlesSubmitBallotUnfoundAccessCode()
         {
-            var usedAccessCode = new UsedAccessCodeModel { AccessCode = "accesscode3" };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = "blah", Election = MoqData.MockBallotData[1].Election };
 
-            var ret = await _ballotApi.UseAccessCode(usedAccessCode);
-            Assert.NotNull(ret);
-            Assert.Equal(StatusCodes.Status200OK, ((IStatusCodeActionResult) ret).StatusCode);
-
-            _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
-            _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
-        }
-
-        [Fact]
-        public async Task HandlesWhenCodeAlreadyUsed()
-        {
-            var usedAccessCode = new UsedAccessCodeModel { AccessCode = "accesscode2" };
-
-            var ret = await _ballotApi.UseAccessCode(usedAccessCode);
-            Assert.NotNull(ret);
-            Assert.Equal(StatusCodes.Status409Conflict, ((IStatusCodeActionResult) ret).StatusCode);
-
-            var val = (SecureString) (ret as ConflictObjectResult).Value;
-            Assert.Contains("AccessCode", val.Value.ToString());
-            Assert.Contains("already used", val.Value.ToString());
-
-            _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
-            _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
-        }
-
-        [Fact]
-        public async Task HandlesWhenCodeDoesNotExist()
-        {
-            var usedAccessCode = new UsedAccessCodeModel { AccessCode = "blah" };
-
-            var ret = await _ballotApi.UseAccessCode(usedAccessCode);
+            var ret = await _ballotApi.SubmitBallot(baseBallotObj);
             Assert.NotNull(ret);
             Assert.Equal(StatusCodes.Status404NotFound, ((IStatusCodeActionResult) ret).StatusCode);
 
             var val = (SecureString) (ret as NotFoundObjectResult).Value;
-            Assert.Contains("AccessCode", val.Value.ToString());
-            Assert.Contains("not found", val.Value.ToString());
+            Assert.NotNull(val);
+            Assert.Contains("AccessCode", val.Value);
+            Assert.Contains("not found", val.Value);
+
+            _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
+            _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task HandlesSubmitBallotAlreadyUsedAccessCode()
+        {
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[1].Election };
+
+            var ret = await _ballotApi.SubmitBallot(baseBallotObj);
+            Assert.NotNull(ret);
+            Assert.Equal(StatusCodes.Status409Conflict, ((IStatusCodeActionResult) ret).StatusCode);
+
+            var val = (SecureString) (ret as ConflictObjectResult).Value;
+            Assert.NotNull(val);
+            Assert.Contains("AccessCode", val.Value);
+            Assert.Contains("already used", val.Value);
 
             _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
             _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));

--- a/TrueVote.Api.Tests/ServiceTests/BallotTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/BallotTest.cs
@@ -26,7 +26,7 @@ namespace TrueVote.Api.Tests.ServiceTests
         [Fact]
         public async Task SubmitsBallot()
         {
-            var baseBallotObj = new SubmitBallotModel { Election = MoqData.MockBallotData[1].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[1].Election };
 
             var ret = await _ballotApi.SubmitBallot(baseBallotObj);
             Assert.NotNull(ret);
@@ -50,7 +50,7 @@ namespace TrueVote.Api.Tests.ServiceTests
         [Fact]
         public async Task SubmitsBallotWithAboveCandidateCountNumberOfMaxChoices()
         {
-            var baseBallotObj = new SubmitBallotModel { Election = MoqData.MockBallotData[1].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[1].Election };
             baseBallotObj.Election.Races[0].MaxNumberOfChoices = 1;
             baseBallotObj.Election.Races[0].Candidates[0].Selected = true;
             baseBallotObj.Election.Races[0].Candidates[1].Selected = true;
@@ -79,7 +79,7 @@ namespace TrueVote.Api.Tests.ServiceTests
         [Fact]
         public async Task SubmitsBallotWithBelowCandidateCountNumberOfMinChoices()
         {
-            var baseBallotObj = new SubmitBallotModel { Election = MoqData.MockBallotData[1].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[1].Election };
             baseBallotObj.Election.Races[0].MinNumberOfChoices = 2;
             baseBallotObj.Election.Races[0].Candidates[0].Selected = true;
 
@@ -107,7 +107,7 @@ namespace TrueVote.Api.Tests.ServiceTests
         [Fact]
         public async Task HandlesSubmitBallotHashingError()
         {
-            var baseBallotObj = new SubmitBallotModel { Election = MoqData.MockBallotData[1].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[1].Election };
 
             var mockValidator = new Mock<IBallotValidator>();
             mockValidator.Setup(m => m.HashBallotAsync(It.IsAny<BallotModel>())).Throws(new Exception("Hash Ballot Exception"));
@@ -207,7 +207,7 @@ namespace TrueVote.Api.Tests.ServiceTests
         [Fact]
         public async Task HandlesSubmitBallotDatabaseError()
         {
-            var baseBallotObj = new SubmitBallotModel { Election = MoqData.MockBallotData[1].Election };
+            var baseBallotObj = new SubmitBallotModel { AccessCode = MoqData.MockUsedAccessCodeData[0].AccessCode, Election = MoqData.MockBallotData[1].Election };
 
             var mockBallotContext = new Mock<MoqTrueVoteDbContext>();
             var mockBallotDataQueryable = MoqData.MockBallotData.AsQueryable();

--- a/TrueVote.Api.Tests/ServiceTests/ElectionTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/ElectionTest.cs
@@ -351,52 +351,5 @@ namespace TrueVote.Api.Tests.ServiceTests
             _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
             _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
         }
-
-        [Fact]
-        public async Task AddsUsedAccessCode()
-        {
-            var usedAccessCode = new UsedAccessCodeModel { AccessCode = "accesscode3" };
-
-            var ret = await _electionApi.UseAccessCode(usedAccessCode);
-            Assert.NotNull(ret);
-            Assert.Equal(StatusCodes.Status200OK, ((IStatusCodeActionResult) ret).StatusCode);
-
-            _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
-            _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
-        }
-
-        [Fact]
-        public async Task HandlesWhenCodeAlreadyUsed()
-        {
-            var usedAccessCode = new UsedAccessCodeModel { AccessCode = "accesscode2" };
-
-            var ret = await _electionApi.UseAccessCode(usedAccessCode);
-            Assert.NotNull(ret);
-            Assert.Equal(StatusCodes.Status409Conflict, ((IStatusCodeActionResult) ret).StatusCode);
-
-            var val = (SecureString) (ret as ConflictObjectResult).Value;
-            Assert.Contains("AccessCode", val.Value.ToString());
-            Assert.Contains("already used", val.Value.ToString());
-
-            _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
-            _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
-        }
-
-        [Fact]
-        public async Task HandlesWhenCodeDoesNotExist()
-        {
-            var usedAccessCode = new UsedAccessCodeModel { AccessCode = "blah" };
-
-            var ret = await _electionApi.UseAccessCode(usedAccessCode);
-            Assert.NotNull(ret);
-            Assert.Equal(StatusCodes.Status404NotFound, ((IStatusCodeActionResult) ret).StatusCode);
-
-            var val = (SecureString) (ret as NotFoundObjectResult).Value;
-            Assert.Contains("AccessCode", val.Value.ToString());
-            Assert.Contains("not found", val.Value.ToString());
-
-            _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
-            _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
-        }
     }
 }

--- a/TrueVote.Api.Tests/ServiceTests/ElectionTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/ElectionTest.cs
@@ -351,5 +351,17 @@ namespace TrueVote.Api.Tests.ServiceTests
             _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
             _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
         }
+
+        [Fact]
+        public async Task AddsUsedAccessCode()
+        {
+            var usedAccessCode = new UsedAccessCodeModel { AccessCode = "accesscode3" };
+
+            var ret = await _electionApi.UseAccessCode(usedAccessCode);
+            Assert.True(ret);
+
+            _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
+            _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
+        }
     }
 }

--- a/TrueVote.Api.Tests/ServiceTests/ElectionTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/ElectionTest.cs
@@ -358,7 +358,42 @@ namespace TrueVote.Api.Tests.ServiceTests
             var usedAccessCode = new UsedAccessCodeModel { AccessCode = "accesscode3" };
 
             var ret = await _electionApi.UseAccessCode(usedAccessCode);
-            Assert.True(ret);
+            Assert.NotNull(ret);
+            Assert.Equal(StatusCodes.Status200OK, ((IStatusCodeActionResult) ret).StatusCode);
+
+            _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
+            _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task HandlesWhenCodeAlreadyUsed()
+        {
+            var usedAccessCode = new UsedAccessCodeModel { AccessCode = "accesscode2" };
+
+            var ret = await _electionApi.UseAccessCode(usedAccessCode);
+            Assert.NotNull(ret);
+            Assert.Equal(StatusCodes.Status409Conflict, ((IStatusCodeActionResult) ret).StatusCode);
+
+            var val = (SecureString) (ret as ConflictObjectResult).Value;
+            Assert.Contains("AccessCode", val.Value.ToString());
+            Assert.Contains("already used", val.Value.ToString());
+
+            _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
+            _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));
+        }
+
+        [Fact]
+        public async Task HandlesWhenCodeDoesNotExist()
+        {
+            var usedAccessCode = new UsedAccessCodeModel { AccessCode = "blah" };
+
+            var ret = await _electionApi.UseAccessCode(usedAccessCode);
+            Assert.NotNull(ret);
+            Assert.Equal(StatusCodes.Status404NotFound, ((IStatusCodeActionResult) ret).StatusCode);
+
+            var val = (SecureString) (ret as NotFoundObjectResult).Value;
+            Assert.Contains("AccessCode", val.Value.ToString());
+            Assert.Contains("not found", val.Value.ToString());
 
             _logHelper.Verify(LogLevel.Information, Times.Exactly(1));
             _logHelper.Verify(LogLevel.Debug, Times.Exactly(2));

--- a/TrueVote.Api.Tests/ServiceTests/QueryTest.cs
+++ b/TrueVote.Api.Tests/ServiceTests/QueryTest.cs
@@ -20,7 +20,7 @@ namespace TrueVote.Api.Tests.ServiceTests
             Assert.NotNull(ret);
             Assert.Equal("Jane Doe", ret[0].Name);
             Assert.Equal("John Smith", ret[1].Name);
-            Assert.True(ret.Count == 2);
+            Assert.Equal(2, ret.Count);
         }
 
         [Fact]
@@ -32,7 +32,7 @@ namespace TrueVote.Api.Tests.ServiceTests
 
             Assert.NotNull(ret);
             Assert.Equal("John Smith", ret[0].Name);
-            Assert.True(ret.Count == 1);
+            Assert.Single(ret);
         }
 
         [Fact]
@@ -43,7 +43,7 @@ namespace TrueVote.Api.Tests.ServiceTests
             Assert.NotNull(ret);
             Assert.Equal("Union", ret[0].Name);
             Assert.Equal("Association", ret[1].Name);
-            Assert.True(ret.Count == 5);
+            Assert.Equal(5, ret.Count);
         }
 
         [Fact]
@@ -56,7 +56,7 @@ namespace TrueVote.Api.Tests.ServiceTests
             Assert.NotNull(ret);
             Assert.Equal("Federal", ret[0].Name);
             Assert.Equal("electionid3", ret[0].ElectionId);
-            Assert.True(ret.Count == 1);
+            Assert.Single(ret);
         }
 
         [Fact]
@@ -71,7 +71,7 @@ namespace TrueVote.Api.Tests.ServiceTests
             Assert.Equal("Judge", ret[1].Name);
             Assert.Equal(RaceTypes.ChooseMany, ret[1].RaceType);
             Assert.Equal("ChooseMany", ret[1].RaceTypeName);
-            Assert.True(ret.Count == 3);
+            Assert.Equal(3, ret.Count);
         }
 
         [Fact]
@@ -82,7 +82,7 @@ namespace TrueVote.Api.Tests.ServiceTests
             Assert.NotNull(ret);
             Assert.Equal("Boo Bar", ret[0].FullName);
             Assert.Equal("Foo2 Bar", ret[1].FullName);
-            Assert.True(ret.Count == 3);
+            Assert.Equal(3, ret.Count);
         }
 
         [Fact]
@@ -93,7 +93,7 @@ namespace TrueVote.Api.Tests.ServiceTests
             Assert.NotNull(ret);
             Assert.Equal("electionid5", ret.Ballots[0].Election.ElectionId);
             Assert.Equal("ballotid5", ret.Ballots[0].BallotId);
-            Assert.True(ret.Ballots.Count == 5);
+            Assert.Equal(5, ret.Ballots.Count);
         }
 
         [Fact]
@@ -106,7 +106,7 @@ namespace TrueVote.Api.Tests.ServiceTests
             Assert.NotNull(ret);
             Assert.Equal("electionid1", ret.Ballots[0].Election.ElectionId);
             Assert.Equal("ballotid3", ret.Ballots[0].BallotId);
-            Assert.True(ret.Ballots.Count == 1);
+            Assert.Single(ret.Ballots);
         }
 
         [Fact]
@@ -118,10 +118,10 @@ namespace TrueVote.Api.Tests.ServiceTests
 
             Assert.NotNull(ret);
             Assert.Equal("electionid1", ret[0].ElectionId);
-            Assert.Equal("accesscode1", ret[0].AccessCode);
+            Assert.Equal("accesscode0", ret[0].AccessCode);
             Assert.Equal("electionid1", ret[1].ElectionId);
-            Assert.Equal("accesscode2", ret[1].AccessCode);
-            Assert.True(ret.Count == 2);
+            Assert.Equal("accesscode1", ret[1].AccessCode);
+            Assert.Equal(3, ret.Count);
         }
 
         [Fact]
@@ -134,7 +134,7 @@ namespace TrueVote.Api.Tests.ServiceTests
             Assert.NotNull(ret);
             Assert.Equal("electionid1", ret[0].ElectionId);
             Assert.Equal("accesscode1", ret[0].AccessCode);
-            Assert.True(ret.Count == 1);
+            Assert.Single(ret);
         }
     }
 }

--- a/TrueVote.Api/Interfaces/ITrueVoteDbContext.cs
+++ b/TrueVote.Api/Interfaces/ITrueVoteDbContext.cs
@@ -14,6 +14,7 @@ namespace TrueVote.Api.Interfaces
         DbSet<BallotHashModel> BallotHashes { get; set; }
         DbSet<FeedbackModel> Feedbacks { get; set; }
         DbSet<AccessCodeModel> ElectionAccessCodes { get; set; }
+        DbSet<UsedAccessCodeModel> UsedAccessCodes { get; set; }
 
         Task<bool> EnsureCreatedAsync();
         Task<int> SaveChangesAsync();

--- a/TrueVote.Api/Models/BallotModel.cs
+++ b/TrueVote.Api/Models/BallotModel.cs
@@ -92,7 +92,8 @@ namespace TrueVote.Api.Models
         public required DateTime DateCreated { get; set; }
     }
 
-    public class SubmitBallotModel {
+    public class SubmitBallotModel
+    {
         [Required]
         [Description("Election")]
         [DataType("ElectionModel")]
@@ -100,6 +101,15 @@ namespace TrueVote.Api.Models
         [JsonProperty(nameof(Election), Required = Required.Always)]
         [BallotIntegrityChecker(nameof(Election))]
         public required ElectionModel Election { get; set; }
+
+        // We don't store the AccessCode with the ballot. That could identify the user that submitted the ballot. It's passed in with the payload, but stored decoupled. See SubmitBallot()
+        [Required]
+        [Description("Access Code")]
+        [MaxLength(16)]
+        [DataType(DataType.Text)]
+        [JsonPropertyName("AccessCode")]
+        [JsonProperty(nameof(AccessCode), Required = Required.Always)]
+        public required string AccessCode { get; set; }
 
         // TODO Add Bindings of User / Ballot connection
         // Requires encryption for binding stored at client and server for match

--- a/TrueVote.Api/Models/ElectionModel.cs
+++ b/TrueVote.Api/Models/ElectionModel.cs
@@ -202,6 +202,21 @@ namespace TrueVote.Api.Models
         public required string AccessCode { get; set; }
     }
 
+    // This model is bare bones, with no timestamp. Because if we were to store a timestamp, heuristics could be used to see the timestamp of this Date and match it to the Ballot Date,
+    // and then determine the access code used to submit the ballot. With that info, the user that submitted the ballot could be determined.
+    // So we just store the raw access code in a table to determine if it was used or not.
+    public class UsedAccessCodeModel
+    {
+        [Required]
+        [Description("Access Code")]
+        [MaxLength(16)]
+        [DataType(DataType.Text)]
+        [JsonPropertyName("AccessCode")]
+        [JsonProperty(nameof(AccessCode), Required = Required.Always)]
+        [Key]
+        public required string AccessCode { get; set; }
+    }
+
     public class AccessCodesResponse
     {
         [Required]

--- a/TrueVote.Api/Services/Ballot.cs
+++ b/TrueVote.Api/Services/Ballot.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.ComponentModel.DataAnnotations;
+using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 using TrueVote.Api.Helpers;
@@ -35,6 +36,8 @@ namespace TrueVote.Api.Services
         }
 
         [HttpPost]
+        [Authorize]
+        [ServiceFilter(typeof(ValidateUserIdFilter))]
         [Route("ballot/submitballot")]
         [Produces(typeof(SubmitBallotModelResponse))]
         [Description("Election Model with vote selections")]

--- a/TrueVote.Api/Services/Ballot.cs
+++ b/TrueVote.Api/Services/Ballot.cs
@@ -190,5 +190,39 @@ namespace TrueVote.Api.Services
 
             return items.Count == 0 ? NotFound() : Ok(items);
         }
+
+        // public (for testing) internal method for AccessCode usage
+        public async Task<IActionResult> UseAccessCode(UsedAccessCodeModel usedAccessCode)
+        {
+            _log.LogDebug("Non-Public Function - UseAccessCode:Begin");
+
+            _log.LogInformation($"Request Data: {usedAccessCode}");
+
+            // Determine if the EAC exists
+            var accessCode = await _trueVoteDbContext.ElectionAccessCodes.Where(u => u.AccessCode == usedAccessCode.AccessCode).FirstOrDefaultAsync();
+            if (accessCode == null)
+            {
+                _log.LogDebug("Non-Public Function - UseAccessCode:End");
+                return NotFound(new SecureString { Value = $"AccessCode: '{usedAccessCode.AccessCode}' not found" });
+            }
+
+            // Determine if EAC was already used
+            var alreadyUsed = await _trueVoteDbContext.UsedAccessCodes.Where(u => u.AccessCode == usedAccessCode.AccessCode).FirstOrDefaultAsync();
+            if (alreadyUsed != null)
+            {
+                _log.LogDebug("Non-Public Function - UseAccessCode:End");
+                return Conflict(new SecureString { Value = $"AccessCode: '{usedAccessCode.AccessCode}' already used" });
+            }
+
+            // Add it
+            await _trueVoteDbContext.EnsureCreatedAsync();
+
+            await _trueVoteDbContext.UsedAccessCodes.AddAsync(usedAccessCode);
+            await _trueVoteDbContext.SaveChangesAsync();
+
+            _log.LogDebug("Non-Public Function - UseAccessCode:End");
+
+            return Ok();
+        }
     }
 }

--- a/TrueVote.Api/Services/Election.cs
+++ b/TrueVote.Api/Services/Election.cs
@@ -257,8 +257,8 @@ namespace TrueVote.Api.Services
             return Ok(election);
         }
 
-        // TODO Should return a status and string error message
-        public async Task<bool> UseAccessCode(UsedAccessCodeModel usedAccessCode)
+        // public (for testing) internal method for AccessCode usage
+        public async Task<IActionResult> UseAccessCode(UsedAccessCodeModel usedAccessCode)
         {
             _log.LogDebug("Non-Public Function - UseAccessCode:Begin");
 
@@ -269,7 +269,7 @@ namespace TrueVote.Api.Services
             if (accessCode == null)
             {
                 _log.LogDebug("Non-Public Function - UseAccessCode:End");
-                return false;
+                return NotFound(new SecureString { Value = $"AccessCode: '{usedAccessCode.AccessCode}' not found" });
             }
 
             // Determine if EAC was already used
@@ -277,7 +277,7 @@ namespace TrueVote.Api.Services
             if (alreadyUsed != null)
             {
                 _log.LogDebug("Non-Public Function - UseAccessCode:End");
-                return false;
+                return Conflict(new SecureString { Value = $"AccessCode: '{usedAccessCode.AccessCode}' already used" });
             }
 
             // Add it
@@ -288,7 +288,7 @@ namespace TrueVote.Api.Services
 
             _log.LogDebug("Non-Public Function - UseAccessCode:End");
 
-            return true;
+            return Ok();
         }
     }
 }

--- a/TrueVote.Api/Services/Election.cs
+++ b/TrueVote.Api/Services/Election.cs
@@ -256,5 +256,39 @@ namespace TrueVote.Api.Services
 
             return Ok(election);
         }
+
+        // TODO Should return a status and string error message
+        public async Task<bool> UseAccessCode(UsedAccessCodeModel usedAccessCode)
+        {
+            _log.LogDebug("Non-Public Function - UseAccessCode:Begin");
+
+            _log.LogInformation($"Request Data: {usedAccessCode}");
+
+            // Determine if the EAC exists
+            var accessCode = await _trueVoteDbContext.ElectionAccessCodes.Where(u => u.AccessCode == usedAccessCode.AccessCode).FirstOrDefaultAsync();
+            if (accessCode == null)
+            {
+                _log.LogDebug("Non-Public Function - UseAccessCode:End");
+                return false;
+            }
+
+            // Determine if EAC was already used
+            var alreadyUsed = await _trueVoteDbContext.UsedAccessCodes.Where(u => u.AccessCode == usedAccessCode.AccessCode).FirstOrDefaultAsync();
+            if (alreadyUsed != null)
+            {
+                _log.LogDebug("Non-Public Function - UseAccessCode:End");
+                return false;
+            }
+
+            // Add it
+            await _trueVoteDbContext.EnsureCreatedAsync();
+
+            await _trueVoteDbContext.UsedAccessCodes.AddAsync(usedAccessCode);
+            await _trueVoteDbContext.SaveChangesAsync();
+
+            _log.LogDebug("Non-Public Function - UseAccessCode:End");
+
+            return true;
+        }
     }
 }

--- a/TrueVote.Api/Services/Election.cs
+++ b/TrueVote.Api/Services/Election.cs
@@ -256,39 +256,5 @@ namespace TrueVote.Api.Services
 
             return Ok(election);
         }
-
-        // public (for testing) internal method for AccessCode usage
-        public async Task<IActionResult> UseAccessCode(UsedAccessCodeModel usedAccessCode)
-        {
-            _log.LogDebug("Non-Public Function - UseAccessCode:Begin");
-
-            _log.LogInformation($"Request Data: {usedAccessCode}");
-
-            // Determine if the EAC exists
-            var accessCode = await _trueVoteDbContext.ElectionAccessCodes.Where(u => u.AccessCode == usedAccessCode.AccessCode).FirstOrDefaultAsync();
-            if (accessCode == null)
-            {
-                _log.LogDebug("Non-Public Function - UseAccessCode:End");
-                return NotFound(new SecureString { Value = $"AccessCode: '{usedAccessCode.AccessCode}' not found" });
-            }
-
-            // Determine if EAC was already used
-            var alreadyUsed = await _trueVoteDbContext.UsedAccessCodes.Where(u => u.AccessCode == usedAccessCode.AccessCode).FirstOrDefaultAsync();
-            if (alreadyUsed != null)
-            {
-                _log.LogDebug("Non-Public Function - UseAccessCode:End");
-                return Conflict(new SecureString { Value = $"AccessCode: '{usedAccessCode.AccessCode}' already used" });
-            }
-
-            // Add it
-            await _trueVoteDbContext.EnsureCreatedAsync();
-
-            await _trueVoteDbContext.UsedAccessCodes.AddAsync(usedAccessCode);
-            await _trueVoteDbContext.SaveChangesAsync();
-
-            _log.LogDebug("Non-Public Function - UseAccessCode:End");
-
-            return Ok();
-        }
     }
 }

--- a/TrueVote.Api/Startup.cs
+++ b/TrueVote.Api/Startup.cs
@@ -234,6 +234,8 @@ namespace TrueVote.Api
             public virtual DbSet<BallotHashModel> BallotHashes { get; set; }
             public virtual DbSet<FeedbackModel> Feedbacks { get; set; }
             public virtual DbSet<AccessCodeModel> ElectionAccessCodes { get; set; }
+            public virtual DbSet<UsedAccessCodeModel> UsedAccessCodes { get; set; }
+
             private readonly IConfiguration? _configuration;
             private readonly string? _connectionString;
 
@@ -322,6 +324,11 @@ namespace TrueVote.Api
                 modelBuilder.Entity<AccessCodeModel>().ToContainer("ElectionAccessCodes");
                 modelBuilder.Entity<AccessCodeModel>().HasNoDiscriminator();
                 modelBuilder.Entity<AccessCodeModel>().HasKey(ac => new { ac.RequestId, ac.AccessCode, ac.ElectionId });
+
+                modelBuilder.HasDefaultContainer("UsedAccessCodes");
+                modelBuilder.Entity<UsedAccessCodeModel>().ToContainer("UsedAccessCodes");
+                modelBuilder.Entity<UsedAccessCodeModel>().HasNoDiscriminator();
+                modelBuilder.Entity<UsedAccessCodeModel>().HasKey(ac => new { ac.AccessCode });
             }
         }
 


### PR DESCRIPTION
Added UsedAccessCodes with no timestamp, ensuring access codes can only be used once and cannot be bound to a ballot or user using heuristics.
